### PR TITLE
Create decidim-bulletin-board gem scaffold

### DIFF
--- a/.github/workflows/app-workflow.yml
+++ b/.github/workflows/app-workflow.yml
@@ -1,4 +1,4 @@
-name: "[CI] Lint"
+name: "[CI] Application"
 on:
   push:
     paths:

--- a/.github/workflows/client-ruby-workflow.yml
+++ b/.github/workflows/client-ruby-workflow.yml
@@ -1,0 +1,46 @@
+name: "[CI] Ruby Client"
+on: push
+# on:
+#   push:
+#     paths:
+#       - "decidim-bulletin-board-client-ruby/**"
+
+env:
+  CI: "true"
+  SIMPLECOV: "true"
+  RUBY_VERSION: 2.6.6
+
+defaults:
+  run:
+    working-directory: ./decidim-bulletin-board-client-ruby
+
+jobs:
+  lint:
+    name: Lint code
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.0.0
+        with:
+          fetch-depth: 1
+      - uses: ruby/setup-ruby@master
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+      - name: Recover dependency cache
+        uses: actions/cache@v1
+        with:
+          path: ./decidim-bulletin-board-client-ruby/vendor/bundle
+          key: ${{ runner.OS }}-decidim-bulletin-board-client-ruby-deps-${{ hashFiles('decidim-bulletin-board-client-ruby/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.OS }}-decidim-bulletin-board-client-ruby-deps-${{ env.cache-name }}-
+            ${{ runner.OS }}-decidim-bulletin-board-client-ruby-deps-
+            ${{ runner.OS }}-decidim-bulletin-board-client-ruby-
+      - name: Install Ruby deps
+        uses: nick-invision/retry@v1
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          command: cd decidim-bulletin-board-client-ruby && bundle install --path vendor/bundle --jobs 4 --retry 3
+      - name: Install Rubocop
+        run: gem install rubocop
+      - run: bundle exec rubocop -P
+        name: Lint Ruby files

--- a/.github/workflows/client-ruby-workflow.yml
+++ b/.github/workflows/client-ruby-workflow.yml
@@ -1,9 +1,8 @@
 name: "[CI] Ruby Client"
-on: push
-# on:
-#   push:
-#     paths:
-#       - "decidim-bulletin-board-client-ruby/**"
+on:
+  push:
+    paths:
+      - "decidim-bulletin-board-client-ruby/**"
 
 env:
   CI: "true"
@@ -44,3 +43,31 @@ jobs:
         run: gem install rubocop
       - run: bundle exec rubocop -P
         name: Lint Ruby files
+  rspec-test:
+    name: RSpec tests
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.0.0
+        with:
+          fetch-depth: 1
+      - uses: ruby/setup-ruby@master
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+      - name: Recover dependency cache
+        uses: actions/cache@v1
+        with:
+          path: ./decidim-bulletin-board-client-ruby/vendor/bundle
+          key: ${{ runner.OS }}-decidim-bulletin-board-client-ruby-deps-${{ hashFiles('decidim-bulletin-board-client-ruby/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.OS }}-decidim-bulletin-board-client-ruby-deps-${{ env.cache-name }}-
+            ${{ runner.OS }}-decidim-bulletin-board-client-ruby-deps-
+            ${{ runner.OS }}-decidim-bulletin-board-client-ruby-
+      - name: Install Ruby deps
+        uses: nick-invision/retry@v1
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          command: cd decidim-bulletin-board-client-ruby && bundle install --path vendor/bundle --jobs 4 --retry 3
+      - name: Run tests
+        run: bundler exec rake

--- a/README.md
+++ b/README.md
@@ -3,3 +3,4 @@
 This repository follows the monorepo pattern and includes the following projects:
 
 - **decidim-bulletin-board-app**: A Ruby on Rails application that contains the Bulletin Board service. You can check the project details [here](https://github.com/decidim/decidim-bulletin-board/blob/master/decidim-bulletin-board-app/README.md).
+- **decidim-bulletin-board-client-ruby**: A Ruby gem that can be included in other applications to interact with the Bulletin Board application. You can check the project details [here](https://github.com/decidim/decidim-bulletin-board/blob/master/decidim-bulletin-board-client-ruby/README.md).

--- a/decidim-bulletin-board-client-ruby/.gitignore
+++ b/decidim-bulletin-board-client-ruby/.gitignore
@@ -1,0 +1,11 @@
+/.bundle/
+/.yardoc
+/_yardoc/
+/coverage/
+/doc/
+/pkg/
+/spec/reports/
+/tmp/
+
+# rspec failure tracking
+.rspec_status

--- a/decidim-bulletin-board-client-ruby/.rspec
+++ b/decidim-bulletin-board-client-ruby/.rspec
@@ -1,0 +1,3 @@
+--format documentation
+--color
+--require spec_helper

--- a/decidim-bulletin-board-client-ruby/.travis.yml
+++ b/decidim-bulletin-board-client-ruby/.travis.yml
@@ -1,0 +1,6 @@
+---
+language: ruby
+cache: bundler
+rvm:
+  - 2.7.1
+before_install: gem install bundler -v 2.1.4

--- a/decidim-bulletin-board-client-ruby/CODE_OF_CONDUCT.md
+++ b/decidim-bulletin-board-client-ruby/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at david@codegram.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [https://contributor-covenant.org/version/1/4][version]
+
+[homepage]: https://contributor-covenant.org
+[version]: https://contributor-covenant.org/version/1/4/

--- a/decidim-bulletin-board-client-ruby/Gemfile
+++ b/decidim-bulletin-board-client-ruby/Gemfile
@@ -1,7 +1,9 @@
-source "https://rubygems.org"
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
 
 # Specify your gem's dependencies in decidim-bulletin_board.gemspec
 gemspec
 
-gem "rake", "~> 12.0"
-gem "rspec", "~> 3.0"
+gem 'rake', '~> 12.0'
+gem 'rspec', '~> 3.0'

--- a/decidim-bulletin-board-client-ruby/Gemfile
+++ b/decidim-bulletin-board-client-ruby/Gemfile
@@ -1,0 +1,7 @@
+source "https://rubygems.org"
+
+# Specify your gem's dependencies in decidim-bulletin_board.gemspec
+gemspec
+
+gem "rake", "~> 12.0"
+gem "rspec", "~> 3.0"

--- a/decidim-bulletin-board-client-ruby/Gemfile.lock
+++ b/decidim-bulletin-board-client-ruby/Gemfile.lock
@@ -1,0 +1,55 @@
+PATH
+  remote: .
+  specs:
+    decidim-bulletin_board (0.1.0)
+      rubocop (~> 0.92.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.1)
+    diff-lcs (1.4.4)
+    parallel (1.20.0)
+    parser (2.7.2.0)
+      ast (~> 2.4.1)
+    rainbow (3.0.0)
+    rake (12.3.3)
+    regexp_parser (1.8.2)
+    rexml (3.2.4)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.0)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.0)
+    rubocop (0.92.0)
+      parallel (~> 1.10)
+      parser (>= 2.7.1.5)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.7)
+      rexml
+      rubocop-ast (>= 0.5.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
+    rubocop-ast (1.1.1)
+      parser (>= 2.7.1.5)
+    ruby-progressbar (1.10.1)
+    unicode-display_width (1.7.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  decidim-bulletin_board!
+  rake (~> 12.0)
+  rspec (~> 3.0)
+
+BUNDLED WITH
+   2.1.4

--- a/decidim-bulletin-board-client-ruby/LICENSE.txt
+++ b/decidim-bulletin-board-client-ruby/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2020 David Morcillo
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/decidim-bulletin-board-client-ruby/README.md
+++ b/decidim-bulletin-board-client-ruby/README.md
@@ -1,0 +1,44 @@
+# Decidim::BulletinBoard
+
+Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/decidim/bulletin_board`. To experiment with that code, run `bin/console` for an interactive prompt.
+
+TODO: Delete this and the text above, and describe your gem
+
+## Installation
+
+Add this line to your application's Gemfile:
+
+```ruby
+gem 'decidim-bulletin_board'
+```
+
+And then execute:
+
+    $ bundle install
+
+Or install it yourself as:
+
+    $ gem install decidim-bulletin_board
+
+## Usage
+
+TODO: Write usage instructions here
+
+## Development
+
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+
+To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+
+## Contributing
+
+Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/decidim-bulletin_board. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/[USERNAME]/decidim-bulletin_board/blob/master/CODE_OF_CONDUCT.md).
+
+
+## License
+
+The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
+
+## Code of Conduct
+
+Everyone interacting in the Decidim::BulletinBoard project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/[USERNAME]/decidim-bulletin_board/blob/master/CODE_OF_CONDUCT.md).

--- a/decidim-bulletin-board-client-ruby/Rakefile
+++ b/decidim-bulletin-board-client-ruby/Rakefile
@@ -1,0 +1,6 @@
+require "bundler/gem_tasks"
+require "rspec/core/rake_task"
+
+RSpec::Core::RakeTask.new(:spec)
+
+task :default => :spec

--- a/decidim-bulletin-board-client-ruby/Rakefile
+++ b/decidim-bulletin-board-client-ruby/Rakefile
@@ -1,6 +1,8 @@
-require "bundler/gem_tasks"
-require "rspec/core/rake_task"
+# frozen_string_literal: true
+
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
 
-task :default => :spec
+task default: :spec

--- a/decidim-bulletin-board-client-ruby/bin/console
+++ b/decidim-bulletin-board-client-ruby/bin/console
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+require "decidim/bulletin_board"
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+# require "pry"
+# Pry.start
+
+require "irb"
+IRB.start(__FILE__)

--- a/decidim-bulletin-board-client-ruby/bin/console
+++ b/decidim-bulletin-board-client-ruby/bin/console
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
-require "bundler/setup"
-require "decidim/bulletin_board"
+require 'bundler/setup'
+require 'decidim/bulletin_board'
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
@@ -10,5 +12,5 @@ require "decidim/bulletin_board"
 # require "pry"
 # Pry.start
 
-require "irb"
+require 'irb'
 IRB.start(__FILE__)

--- a/decidim-bulletin-board-client-ruby/bin/setup
+++ b/decidim-bulletin-board-client-ruby/bin/setup
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+bundle install
+
+# Do any other automated setup that you need to do here

--- a/decidim-bulletin-board-client-ruby/bin/setup
+++ b/decidim-bulletin-board-client-ruby/bin/setup
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# frozen_string_literal: true
+
 set -euo pipefail
 IFS=$'\n\t'
 set -vx

--- a/decidim-bulletin-board-client-ruby/decidim-bulletin_board.gemspec
+++ b/decidim-bulletin-board-client-ruby/decidim-bulletin_board.gemspec
@@ -1,23 +1,27 @@
+# frozen_string_literal: true
+
 require_relative 'lib/decidim/bulletin_board/version'
 
-Gem::Specification.new do |spec|
-  spec.name          = "decidim-bulletin_board"
-  spec.version       = Decidim::BulletinBoard::VERSION
-  spec.authors       = ["David Morcillo"]
-  spec.email         = ["david@codegram.com"]
+Gem::Specification.new do |s|
+  s.name          = 'decidim-bulletin_board'
+  s.version       = Decidim::BulletinBoard::VERSION
+  s.authors       = ['David Morcillo']
+  s.email         = ['david@codegram.com']
 
-  spec.summary       = ""
-  spec.description   = ""
-  spec.homepage      = "https://github.com"
-  spec.license       = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
+  s.summary       = ''
+  s.description   = ''
+  s.homepage      = 'https://github.com'
+  s.license       = 'MIT'
+  s.required_ruby_version = Gem::Requirement.new('>= 2.3.0')
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
+  s.files = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+  s.bindir        = 'exe'
+  s.executables   = s.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  s.require_paths = ['lib']
+
+  s.add_dependency 'rubocop', '~> 0.92.0'
 end

--- a/decidim-bulletin-board-client-ruby/decidim-bulletin_board.gemspec
+++ b/decidim-bulletin-board-client-ruby/decidim-bulletin_board.gemspec
@@ -1,0 +1,23 @@
+require_relative 'lib/decidim/bulletin_board/version'
+
+Gem::Specification.new do |spec|
+  spec.name          = "decidim-bulletin_board"
+  spec.version       = Decidim::BulletinBoard::VERSION
+  spec.authors       = ["David Morcillo"]
+  spec.email         = ["david@codegram.com"]
+
+  spec.summary       = ""
+  spec.description   = ""
+  spec.homepage      = "https://github.com"
+  spec.license       = "MIT"
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
+
+  # Specify which files should be added to the gem when it is released.
+  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
+  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  end
+  spec.bindir        = "exe"
+  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.require_paths = ["lib"]
+end

--- a/decidim-bulletin-board-client-ruby/lib/decidim/bulletin_board.rb
+++ b/decidim-bulletin-board-client-ruby/lib/decidim/bulletin_board.rb
@@ -1,5 +1,8 @@
-require "decidim/bulletin_board/version"
-require "decidim/bulletin_board/client"
+# frozen_string_literal: true
+# frozen_string_literal: true
+
+require 'decidim/bulletin_board/version'
+require 'decidim/bulletin_board/client'
 
 module Decidim
   module BulletinBoard

--- a/decidim-bulletin-board-client-ruby/lib/decidim/bulletin_board.rb
+++ b/decidim-bulletin-board-client-ruby/lib/decidim/bulletin_board.rb
@@ -1,0 +1,9 @@
+require "decidim/bulletin_board/version"
+require "decidim/bulletin_board/client"
+
+module Decidim
+  module BulletinBoard
+    class Error < StandardError; end
+    # Your code goes here...
+  end
+end

--- a/decidim-bulletin-board-client-ruby/lib/decidim/bulletin_board/client.rb
+++ b/decidim-bulletin-board-client-ruby/lib/decidim/bulletin_board/client.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 module Decidim
-    module BulletinBoard
-      class Client
-        def say_hi
-            puts "Hello world!"
-        end
+  module BulletinBoard
+    # The Bulletin Board client
+    class Client
+      def say_hi
+        puts 'Hello world!'
       end
     end
   end
-  
+end

--- a/decidim-bulletin-board-client-ruby/lib/decidim/bulletin_board/client.rb
+++ b/decidim-bulletin-board-client-ruby/lib/decidim/bulletin_board/client.rb
@@ -1,0 +1,10 @@
+module Decidim
+    module BulletinBoard
+      class Client
+        def say_hi
+            puts "Hello world!"
+        end
+      end
+    end
+  end
+  

--- a/decidim-bulletin-board-client-ruby/lib/decidim/bulletin_board/version.rb
+++ b/decidim-bulletin-board-client-ruby/lib/decidim/bulletin_board/version.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module Decidim
   module BulletinBoard
-    VERSION = "0.1.0"
+    VERSION = '0.1.0'
   end
 end

--- a/decidim-bulletin-board-client-ruby/lib/decidim/bulletin_board/version.rb
+++ b/decidim-bulletin-board-client-ruby/lib/decidim/bulletin_board/version.rb
@@ -1,0 +1,5 @@
+module Decidim
+  module BulletinBoard
+    VERSION = "0.1.0"
+  end
+end

--- a/decidim-bulletin-board-client-ruby/spec/decidim/bulletin_board_spec.rb
+++ b/decidim-bulletin-board-client-ruby/spec/decidim/bulletin_board_spec.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 RSpec.describe Decidim::BulletinBoard do
-  it "has a version number" do
+  it 'has a version number' do
     expect(Decidim::BulletinBoard::VERSION).not_to be nil
   end
 
-  it "does something useful" do
+  it 'does something useful' do
     expect(false).to eq(true)
   end
 end

--- a/decidim-bulletin-board-client-ruby/spec/decidim/bulletin_board_spec.rb
+++ b/decidim-bulletin-board-client-ruby/spec/decidim/bulletin_board_spec.rb
@@ -6,6 +6,6 @@ RSpec.describe Decidim::BulletinBoard do
   end
 
   it 'does something useful' do
-    expect(false).to eq(true)
+    expect(true).to eq(true)
   end
 end

--- a/decidim-bulletin-board-client-ruby/spec/decidim/bulletin_board_spec.rb
+++ b/decidim-bulletin-board-client-ruby/spec/decidim/bulletin_board_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe Decidim::BulletinBoard do
+  it "has a version number" do
+    expect(Decidim::BulletinBoard::VERSION).not_to be nil
+  end
+
+  it "does something useful" do
+    expect(false).to eq(true)
+  end
+end

--- a/decidim-bulletin-board-client-ruby/spec/spec_helper.rb
+++ b/decidim-bulletin-board-client-ruby/spec/spec_helper.rb
@@ -1,9 +1,11 @@
-require "bundler/setup"
-require "decidim/bulletin_board"
+# frozen_string_literal: true
+
+require 'bundler/setup'
+require 'decidim/bulletin_board'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
-  config.example_status_persistence_file_path = ".rspec_status"
+  config.example_status_persistence_file_path = '.rspec_status'
 
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!

--- a/decidim-bulletin-board-client-ruby/spec/spec_helper.rb
+++ b/decidim-bulletin-board-client-ruby/spec/spec_helper.rb
@@ -1,0 +1,14 @@
+require "bundler/setup"
+require "decidim/bulletin_board"
+
+RSpec.configure do |config|
+  # Enable flags like --only-failures and --next-failure
+  config.example_status_persistence_file_path = ".rspec_status"
+
+  # Disable RSpec exposing methods globally on `Module` and `main`
+  config.disable_monkey_patching!
+
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+end


### PR DESCRIPTION
This adds a new project to the repository in the folder `decidim-bulletin-board-client-ruby`. This folder will include the `decidim-bulletin_board` gem.
I just created a new gem using the `bundle` command and it is meant to be used in upcoming PRs to move some logic from the `decidim` project to here.