### PR TITLE
feat(js): add Client class to interact with the Bulletin Board

### DIFF
--- a/decidim-bulletin-board-client-js/jest.config.js
+++ b/decidim-bulletin-board-client-js/jest.config.js
@@ -71,14 +71,7 @@ module.exports = {
   // ],
 
   // An array of file extensions your modules use
-  // moduleFileExtensions: [
-  //   "js",
-  //   "json",
-  //   "jsx",
-  //   "ts",
-  //   "tsx",
-  //   "node"
-  // ],
+  moduleFileExtensions: ["js", "gql"],
 
   // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
   // moduleNameMapper: {},
@@ -128,7 +121,7 @@ module.exports = {
   // setupFiles: [],
 
   // A list of paths to modules that run some code to configure or set up the testing framework before each test
-  // setupFilesAfterEnv: [],
+  setupFilesAfterEnv: ["<rootDir>/src/setupTests.js"],
 
   // The number of seconds after which a test is considered as slow and reported as such in the results.
   // slowTestThreshold: 5,
@@ -172,7 +165,10 @@ module.exports = {
   // timers: "real",
 
   // A map from regular expressions to paths to transformers
-  // transform: undefined,
+  transform: {
+    "\\.(gql|graphql)$": "jest-transform-graphql",
+    ".*": "babel-jest",
+  },
 
   // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
   // transformIgnorePatterns: [

--- a/decidim-bulletin-board-client-js/package-lock.json
+++ b/decidim-bulletin-board-client-js/package-lock.json
@@ -4,6 +4,34 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@ably/msgpack-js": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@ably/msgpack-js/-/msgpack-js-0.3.3.tgz",
+      "integrity": "sha512-H7oWg97VyA1JhWUP7YN7zwp9W1ozCqMSsqCcXNz4XLmZNdJKT2ntF/6DPgbviFgUpShjQlbPC/iamisTjwLHdQ==",
+      "requires": {
+        "bops": "~0.0.6"
+      }
+    },
+    "@apollo/client": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.2.7.tgz",
+      "integrity": "sha512-4G80jvBLqenCFUhwkHAAHi2ox6Ygq35BkE38yxammqykZm6KE3tVlcEKGOZi0jpiuGJPC6LIQ0d1gtI8ADPtmg==",
+      "requires": {
+        "@graphql-typed-document-node/core": "^3.0.0",
+        "@types/zen-observable": "^0.8.0",
+        "@wry/context": "^0.5.2",
+        "@wry/equality": "^0.2.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "graphql-tag": "^2.11.0",
+        "hoist-non-react-statics": "^3.3.2",
+        "optimism": "^0.13.0",
+        "prop-types": "^15.7.2",
+        "symbol-observable": "^2.0.0",
+        "ts-invariant": "^0.5.0",
+        "tslib": "^1.10.0",
+        "zen-observable": "^0.8.14"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
@@ -1094,6 +1122,11 @@
         }
       }
     },
+    "@graphql-typed-document-node/core": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.0.tgz",
+      "integrity": "sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg=="
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -1529,6 +1562,19 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "@types/ably": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/ably/-/ably-1.0.0.tgz",
+      "integrity": "sha512-QIWjKv103y29ZbjhRHWTzZLMy0KACcAWY1waO3HCOGQ+0xFad3C2l+1AGewFhHNIHLdicrZ1LRmLOWTx6L2u7Q==",
+      "requires": {
+        "ably": "*"
+      }
+    },
+    "@types/actioncable": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/actioncable/-/actioncable-5.2.3.tgz",
+      "integrity": "sha512-RxPohXyK0PmC+xAnIrdrd/+0Rp5Pc3e0gMIw+Rc4EorbXApS+i8D00dDC6RxDCXNrmQaIBwiu5iCE7JurC38kA=="
+    },
     "@types/babel__core": {
       "version": "7.1.12",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.12.tgz",
@@ -1659,6 +1705,11 @@
       "integrity": "sha512-UEyp8LwZ4Dg30kVU2Q3amHHyTn1jEdhCIE59ANed76GaT1Vp76DD3ZWSAxgCrw6wJ0TqeoBpqmfUHiUDPs//HQ==",
       "dev": true
     },
+    "@types/pusher-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@types/pusher-js/-/pusher-js-4.2.2.tgz",
+      "integrity": "sha512-LP9isBRAFlNzQohQtySJxJjzmy4zQCcv5xGZD2G3rsDnTWfpEkFKyLw3x9711pFAXwwUl9ZivxKkcnFr8umSAQ=="
+    },
     "@types/stack-utils": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
@@ -1679,6 +1730,11 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-15.0.0.tgz",
       "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==",
       "dev": true
+    },
+    "@types/zen-observable": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.1.tgz",
+      "integrity": "sha512-wmk0xQI6Yy7Fs/il4EpOcflG4uonUpYGqvZARESLc2oy4u69fkatFLbJOeW4Q6awO15P4rduAe6xkwHevpXcUQ=="
     },
     "@typescript-eslint/experimental-utils": {
       "version": "4.7.0",
@@ -1934,6 +1990,22 @@
       "integrity": "sha512-WGMaTMTK6NOe29Hw1WBEok9vGLfKg5C6jWzNOS/6HH1YadR+RL+TRWRcSyc81Dzulljhk/Ree9mrDM4Np9GGOQ==",
       "dev": true
     },
+    "@wry/context": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.5.2.tgz",
+      "integrity": "sha512-B/JLuRZ/vbEKHRUiGj6xiMojST1kHhu4WcreLfNN7q9DqQFrb97cWgf/kiYsPSUCAMVN0HzfFc8XjJdzgZzfjw==",
+      "requires": {
+        "tslib": "^1.9.3"
+      }
+    },
+    "@wry/equality": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.2.0.tgz",
+      "integrity": "sha512-Y4d+WH6hs+KZJUC8YKLYGarjGekBrhslDbf/R20oV+AakHPINSitHfDRQz3EGcEWc1luXYNUvMhawWtZVWNGvQ==",
+      "requires": {
+        "tslib": "^1.9.3"
+      }
+    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -1951,6 +2023,16 @@
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
       "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
       "dev": true
+    },
+    "ably": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/ably/-/ably-1.2.4.tgz",
+      "integrity": "sha512-RodcLKlxwFtnBxPhr/Lwr/K4NA/WveyO39cliO4J3qmJsSi3kPZDS2bEHjXGPrzKPi9+zOfJ8revEGa0+PcpuQ==",
+      "requires": {
+        "@ably/msgpack-js": "^0.3.3",
+        "request": "^2.87.0",
+        "ws": "^5.1"
+      }
     },
     "acorn": {
       "version": "8.0.4",
@@ -1988,11 +2070,15 @@
       "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
       "dev": true
     },
+    "actioncable": {
+      "version": "5.2.4-4",
+      "resolved": "https://registry.npmjs.org/actioncable/-/actioncable-5.2.4-4.tgz",
+      "integrity": "sha512-qlsr7nTyGwP5mdGSRL3uJsXgbsZ/T/j3cE7QlmcjRKXDuHcm0X0P95/+Ah/cqtx5F3Q2gFYosppGD0uorF8voQ=="
+    },
     "ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2044,6 +2130,56 @@
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
+      }
+    },
+    "apollo-link": {
+      "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.14.tgz",
+      "integrity": "sha512-p67CMEFP7kOG1JZ0ZkYZwRDa369w5PIjtMjvrQd/HnIV8FRsHRqLqK+oAZQnFa1DDdZtOtHTi+aMIW6EatC2jg==",
+      "requires": {
+        "apollo-utilities": "^1.3.0",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.9.3",
+        "zen-observable-ts": "^0.8.21"
+      },
+      "dependencies": {
+        "ts-invariant": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.4.4.tgz",
+          "integrity": "sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==",
+          "requires": {
+            "tslib": "^1.9.3"
+          }
+        }
+      }
+    },
+    "apollo-utilities": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.4.tgz",
+      "integrity": "sha512-pk2hiWrCXMAy2fRPwEyhvka+mqwzeP60Jr1tRYi5xru+3ko94HI9o6lK0CT33/w4RDlxWchmdhDCrvdr+pHCig==",
+      "requires": {
+        "@wry/equality": "^0.1.2",
+        "fast-json-stable-stringify": "^2.0.0",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "@wry/equality": {
+          "version": "0.1.11",
+          "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.11.tgz",
+          "integrity": "sha512-mwEVBDUVODlsQQ5dfuLUS5/Tf7jqUKyhKYHmVi4fPB6bDMOfWvUPJmKgS1Z7Za/sOI3vzWt4+O7yCiL/70MogA==",
+          "requires": {
+            "tslib": "^1.9.3"
+          }
+        },
+        "ts-invariant": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.4.4.tgz",
+          "integrity": "sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==",
+          "requires": {
+            "tslib": "^1.9.3"
+          }
+        }
       }
     },
     "argparse": {
@@ -2116,7 +2252,6 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-      "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
       }
@@ -2124,8 +2259,7 @@
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "dev": true
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -2139,11 +2273,15 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
+    "async-limiter": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "atob": {
       "version": "2.1.2",
@@ -2154,14 +2292,12 @@
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-      "dev": true
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
-      "dev": true
+      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
     "babel-jest": {
       "version": "26.6.3",
@@ -2282,8 +2418,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
       "version": "0.11.2",
@@ -2340,20 +2475,32 @@
         }
       }
     },
+    "base64-js": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.2.tgz",
+      "integrity": "sha1-Ak8Pcq+iW3X5wO5zzU9V7Bvtl4Q="
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "dev": true,
       "requires": {
         "tweetnacl": "^0.14.3"
+      }
+    },
+    "bops": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/bops/-/bops-0.0.7.tgz",
+      "integrity": "sha1-tKClqDmkBkVK8P4FqLkaenZqVOI=",
+      "requires": {
+        "base64-js": "0.0.2",
+        "to-utf8": "0.0.1"
       }
     },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2458,8 +2605,7 @@
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-      "dev": true
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chalk": {
       "version": "2.4.2",
@@ -2597,7 +2743,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -2629,8 +2774,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "contains-path": {
       "version": "0.1.0",
@@ -2682,8 +2826,16 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cross-fetch": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.6.tgz",
+      "integrity": "sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==",
+      "dev": true,
+      "requires": {
+        "node-fetch": "2.6.1"
+      }
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -2723,7 +2875,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -2837,8 +2988,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -2899,7 +3049,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "dev": true,
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -3704,8 +3853,7 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -3796,14 +3944,12 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-glob": {
       "version": "3.2.4",
@@ -3822,8 +3968,7 @@
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -3914,14 +4059,12 @@
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "dev": true
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -3940,8 +4083,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "2.2.0",
@@ -4016,7 +4158,6 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -4025,7 +4166,6 @@
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -4089,6 +4229,36 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.4.0.tgz",
       "integrity": "sha512-EB3zgGchcabbsU9cFe1j+yxdzKQKAbGUWRb13DsrsMN1yyfmmIq+2+L5MqVWcDCE4V89R5AyUOi7sMOGxdsYtA=="
     },
+    "graphql-ruby-client": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/graphql-ruby-client/-/graphql-ruby-client-1.8.1.tgz",
+      "integrity": "sha512-kaCvRaSSbIkj46EpDoyj/oHIn8H0k/LcXla51cirkSGeey8/KNqd5iDJ/xj1Q/O+FK4HQ9rATi+KvuJMvLBePA==",
+      "requires": {
+        "@types/ably": "^1.0.0",
+        "@types/actioncable": "^5.2.3",
+        "@types/pusher-js": "^4.2.2",
+        "apollo-link": "^1.2.12",
+        "glob": "^7.1.4",
+        "graphql": "^14.3.1",
+        "minimist": "^1.2.0",
+        "typescript": "^3.7.5"
+      },
+      "dependencies": {
+        "graphql": {
+          "version": "14.7.0",
+          "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.7.0.tgz",
+          "integrity": "sha512-l0xWZpoPKpppFzMfvVyFmp9vLN7w/ZZJPefUicMCepfJeQ8sMcztloGYY9DfjVPo6tIUDzU5Hw3MUbIjj9AVVA==",
+          "requires": {
+            "iterall": "^1.2.2"
+          }
+        }
+      }
+    },
+    "graphql-tag": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.11.0.tgz",
+      "integrity": "sha512-VmsD5pJqWJnQZMUeRwrDhfgoyqcfwEkvtpANqcoUG8/tOLkwNgU9mzub/Mc78OJMhHjx7gfAMTxzdG43VGg3bA=="
+    },
     "growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
@@ -4099,14 +4269,12 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-      "dev": true
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
       "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "dev": true,
       "requires": {
         "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
@@ -4185,6 +4353,14 @@
         }
       }
     },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
+      }
+    },
     "hosted-git-info": {
       "version": "2.8.8",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
@@ -4210,7 +4386,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -4276,7 +4451,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -4285,8 +4459,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "interpret": {
       "version": "2.2.0",
@@ -4501,8 +4674,7 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-windows": {
       "version": "1.0.2",
@@ -4541,8 +4713,7 @@
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "istanbul-lib-coverage": {
       "version": "3.0.0",
@@ -4601,6 +4772,11 @@
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
       }
+    },
+    "iterall": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
+      "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg=="
     },
     "jest": {
       "version": "26.6.3",
@@ -4876,6 +5052,16 @@
         "@types/node": "*",
         "jest-mock": "^26.6.2",
         "jest-util": "^26.6.2"
+      }
+    },
+    "jest-fetch-mock": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz",
+      "integrity": "sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==",
+      "dev": true,
+      "requires": {
+        "cross-fetch": "^3.0.4",
+        "promise-polyfill": "^8.1.3"
       }
     },
     "jest-get-type": {
@@ -5375,6 +5561,12 @@
         }
       }
     },
+    "jest-transform-graphql": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/jest-transform-graphql/-/jest-transform-graphql-2.1.0.tgz",
+      "integrity": "sha1-kDy2a7J7wncv0+XdT36bVyMPWCk=",
+      "dev": true
+    },
     "jest-util": {
       "version": "26.6.2",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.6.2.tgz",
@@ -5546,8 +5738,7 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "3.14.0",
@@ -5562,8 +5753,7 @@
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "jsdom": {
       "version": "16.4.0",
@@ -5645,14 +5835,12 @@
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-      "dev": true
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -5663,8 +5851,7 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json5": {
       "version": "2.1.3",
@@ -5679,7 +5866,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -5777,6 +5963,14 @@
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
     },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -5843,14 +6037,12 @@
     "mime-db": {
       "version": "1.44.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
-      "dev": true
+      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
     },
     "mime-types": {
       "version": "2.1.27",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
       "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
-      "dev": true,
       "requires": {
         "mime-db": "1.44.0"
       }
@@ -5865,7 +6057,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -5873,8 +6064,7 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mixin-deep": {
       "version": "1.3.2",
@@ -5947,6 +6137,12 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
+    },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
       "dev": true
     },
     "node-int64": {
@@ -6034,8 +6230,12 @@
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "dev": true
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -6126,7 +6326,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -6138,6 +6337,14 @@
       "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
+      }
+    },
+    "optimism": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.13.0.tgz",
+      "integrity": "sha512-6JAh3dH+YUE4QUdsgUw8nUQyrNeBKfAEKOHMlLkQ168KhIYFIxzPsHakWrRXDnTO+x61RJrS3/2uEt6W0xlocA==",
+      "requires": {
+        "@wry/context": "^0.5.2"
       }
     },
     "optionator": {
@@ -6232,8 +6439,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
       "version": "3.1.1",
@@ -6259,8 +6465,7 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "dev": true
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "picomatch": {
       "version": "2.2.2",
@@ -6360,6 +6565,12 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "promise-polyfill": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.2.0.tgz",
+      "integrity": "sha512-k/TC0mIcPVF6yHhUvwAp7cvL6I2fFV7TzF1DuGPI8mBh4QQazf36xCKEHKTZKRysEoTQoQdKyP25J8MPJp7j5g==",
+      "dev": true
+    },
     "prompts": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.0.tgz",
@@ -6370,11 +6581,20 @@
         "sisteransi": "^1.0.5"
       }
     },
+    "prop-types": {
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
+      }
+    },
     "psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
-      "dev": true
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
     },
     "pump": {
       "version": "3.0.0",
@@ -6389,14 +6609,12 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-      "dev": true
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "randombytes": {
       "version": "2.1.0",
@@ -6406,6 +6624,11 @@
       "requires": {
         "safe-buffer": "^5.1.0"
       }
+    },
+    "react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "read-pkg": {
       "version": "5.2.0",
@@ -6566,7 +6789,6 @@
       "version": "2.88.2",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
       "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -6686,11 +6908,18 @@
       "integrity": "sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==",
       "dev": true
     },
+    "rxjs": {
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
+      "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -6704,8 +6933,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sane": {
       "version": "4.1.0",
@@ -7273,7 +7501,6 @@
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
       "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-      "dev": true,
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -7466,6 +7693,11 @@
         "has-flag": "^4.0.0",
         "supports-color": "^7.0.0"
       }
+    },
+    "symbol-observable": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-2.0.3.tgz",
+      "integrity": "sha512-sQV7phh2WCYAn81oAkakC5qjq2Ml0g8ozqz03wOGnx9dDlG1de6yrF+0RAzSJD8fPUow3PTSMf2SAbOGxb93BA=="
     },
     "symbol-tree": {
       "version": "3.2.4",
@@ -7673,11 +7905,15 @@
         "is-number": "^7.0.0"
       }
     },
+    "to-utf8": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/to-utf8/-/to-utf8-0.0.1.tgz",
+      "integrity": "sha1-0Xrqcv8vujm55DYBvns/9y4ImFI="
+    },
     "tough-cookie": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
       "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "dev": true,
       "requires": {
         "psl": "^1.1.28",
         "punycode": "^2.1.1"
@@ -7690,6 +7926,14 @@
       "dev": true,
       "requires": {
         "punycode": "^2.1.1"
+      }
+    },
+    "ts-invariant": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.5.1.tgz",
+      "integrity": "sha512-k3UpDNrBZpqJFnAAkAHNmSHtNuCxcU6xLiziPgalHRKZHme6T6jnKC8CcXDmk1zbHLQM8pc+rNC1Q6FvXMAl+g==",
+      "requires": {
+        "tslib": "^1.9.3"
       }
     },
     "tsconfig-paths": {
@@ -7724,8 +7968,7 @@
     "tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "tsutils": {
       "version": "3.17.1",
@@ -7740,7 +7983,6 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -7748,8 +7990,7 @@
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "type-check": {
       "version": "0.3.2",
@@ -7780,6 +8021,11 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "typescript": {
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw=="
     },
     "typical": {
       "version": "5.2.0",
@@ -7871,7 +8117,6 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
       "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -7891,8 +8136,7 @@
     "uuid": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "dev": true
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "v8-compile-cache": {
       "version": "2.2.0",
@@ -7933,7 +8177,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -8160,8 +8403,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "1.0.3",
@@ -8182,6 +8424,14 @@
         "is-typedarray": "^1.0.0",
         "signal-exit": "^3.0.2",
         "typedarray-to-buffer": "^3.1.5"
+      }
+    },
+    "ws": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+      "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+      "requires": {
+        "async-limiter": "~1.0.0"
       }
     },
     "xml-name-validator": {
@@ -8229,6 +8479,20 @@
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
+      }
+    },
+    "zen-observable": {
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
+      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
+    },
+    "zen-observable-ts": {
+      "version": "0.8.21",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.21.tgz",
+      "integrity": "sha512-Yj3yXweRc8LdRMrCC8nIc4kkjWecPAUVh0TI0OUrWXx6aX790vLcDlWca6I4vsyCGH3LpWxq0dJRcMOFoVqmeg==",
+      "requires": {
+        "tslib": "^1.9.3",
+        "zen-observable": "^0.8.0"
       }
     }
   }

--- a/decidim-bulletin-board-client-js/package.json
+++ b/decidim-bulletin-board-client-js/package.json
@@ -14,7 +14,11 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "graphql": "^15.4.0"
+    "@apollo/client": "^3.2.7",
+    "actioncable": "^5.2.4-4",
+    "graphql": "^15.4.0",
+    "graphql-ruby-client": "^1.8.1",
+    "rxjs": "^6.6.3"
   },
   "devDependencies": {
     "@babel/core": "^7.12.3",
@@ -29,6 +33,8 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.2.1",
     "jest": "^26.6.3",
+    "jest-fetch-mock": "^3.0.3",
+    "jest-transform-graphql": "^2.1.0",
     "prettier": "2.1.2",
     "webpack": "^5.4.0",
     "webpack-cli": "^4.1.0"

--- a/decidim-bulletin-board-client-js/src/client/__mocks__/graphql-client.js
+++ b/decidim-bulletin-board-client-js/src/client/__mocks__/graphql-client.js
@@ -1,0 +1,57 @@
+import { Subject } from "rxjs";
+
+const logEntriesByElection = {
+  "election-1": {
+    data: {
+      election: {
+        logEntries: [
+          {
+            signedData: "1234",
+          },
+          {
+            signedData: "5678",
+          },
+        ],
+      },
+    },
+  },
+  "election-2": {
+    data: {
+      election: {
+        logEntries: [
+          {
+            signedData: "9012",
+          },
+        ],
+      },
+    },
+  },
+};
+
+export class GraphQLClient {
+  constructor({ apiEndpointUrl, wsEndpointUrl }) {
+    this.apiEndpointUrl = apiEndpointUrl;
+    this.wsEndpointUrl = wsEndpointUrl;
+    this.electionLogEntriesUpdates = new Subject();
+  }
+
+  getElectionLogEntries({ electionId }) {
+    return Promise.resolve(
+      logEntriesByElection[electionId].data.election.logEntries
+    );
+  }
+
+  subscribeToElectionLogEntriesUpdates() {
+    return this.electionLogEntriesUpdates;
+  }
+
+  processKeyCeremonyStep({ signedData }) {
+    return Promise.resolve({
+      signedData,
+    });
+  }
+
+  fakeElectionLogEntryUpdate(logEntry) {
+    this.electionLogEntriesUpdates.next(logEntry);
+  }
+}

--- a/decidim-bulletin-board-client-js/src/client/client.js
+++ b/decidim-bulletin-board-client-js/src/client/client.js
@@ -1,0 +1,56 @@
+import { GraphQLClient } from "./graphql-client";
+
+/**
+ * This is a facade over the API client specific implementation.
+ */
+export class Client {
+  /**
+   * Initializes the API client using the same params.
+   *
+   * @constructor
+   * @param {Object} params - An object that include the same params as the API client.
+   */
+  constructor(params) {
+    this.apiClient = new GraphQLClient(params);
+  }
+
+  /**
+   * Query all log entries for the given election id.
+   *
+   * @param {Object} params - An object that include the following options.
+   *  - {String} electionId - The election's id.
+   * @returns {Promise<Array<Object>>} - A collection of log entries.
+   * @throws Will throw an error if the request is rejected.
+   */
+  getElectionLogEntries({ electionId }) {
+    return this.apiClient.getElectionLogEntries({ electionId });
+  }
+
+  /**
+   * Subscribes to an Observable and executes a callback function with each log entry added.
+   *
+   * @param {Object} params - An object that include the following options.
+   *  - {String} electionId - The election's id.
+   * @param {Function} onNextLogEntryUpdate - A callback function that will be called with each log entry added the election.
+   * @returns {Subscription} - A subscription object that can be manually unsubscribed.
+   */
+  subscribeToElectionLogEntriesUpdates({ electionId }, onNextLogEntryUpdate) {
+    const subscription = this.apiClient.subscribeToElectionLogEntriesUpdates({
+      electionId,
+    });
+
+    return subscription.subscribe(onNextLogEntryUpdate);
+  }
+
+  /**
+   * Process a key ceremony step sending a signed message.
+   *
+   * @param {Object} params - An object that include the following options.
+   *  - {String} electionId - The election's id.
+   * @returns {Promise<Object>} - A pending message created.
+   * @throws Will throw an error if the request is rejected or the data contains an error.
+   */
+  processKeyCeremonyStep({ signedData }) {
+    return this.apiClient.processKeyCeremonyStep({ signedData });
+  }
+}

--- a/decidim-bulletin-board-client-js/src/client/client.test.js
+++ b/decidim-bulletin-board-client-js/src/client/client.test.js
@@ -1,0 +1,63 @@
+import { Client } from "./client";
+
+jest.mock("./graphql-client");
+
+describe("Client", () => {
+  const defaultParams = {
+    apiEndpointUrl: "https://example.org/api",
+    wsEndpointUrl: "wss://example.org/ws",
+  };
+
+  const buildClient = (params = defaultParams) => {
+    return new Client(params);
+  };
+
+  let client;
+
+  beforeEach(() => {
+    client = buildClient();
+  });
+
+  it("initialise the api client with the given params", () => {
+    expect(client.apiClient.apiEndpointUrl).toEqual(
+      defaultParams.apiEndpointUrl
+    );
+    expect(client.apiClient.wsEndpointUrl).toEqual(defaultParams.wsEndpointUrl);
+  });
+
+  describe("getElectionLogEntries", () => {
+    it("returns all the log entries from the corresponding election", async () => {
+      const entries = await client.getElectionLogEntries({
+        electionId: "election-1",
+      });
+      expect(entries.length).toEqual(2);
+    });
+  });
+
+  describe("subscribeToElectionLogEntriesUpdates", () => {
+    it("calls the given callback function when a log entry is added", (done) => {
+      const logEntryUpdate = {
+        signedData: "some-signed-data",
+      };
+      client.subscribeToElectionLogEntriesUpdates(
+        { electionId: "election-1" },
+        (logEntry) => {
+          expect(logEntry).toEqual(logEntryUpdate);
+          done();
+        }
+      );
+      client.apiClient.fakeElectionLogEntryUpdate(logEntryUpdate);
+    });
+  });
+
+  describe("processKeyCeremonyStep", () => {
+    it("calls the api client corresponding method with the correct arguments", async () => {
+      const pendingMessage = await client.processKeyCeremonyStep({
+        signedData: "1234",
+      });
+      expect(pendingMessage).toEqual({
+        signedData: "1234",
+      });
+    });
+  });
+});

--- a/decidim-bulletin-board-client-js/src/client/graphql-client.js
+++ b/decidim-bulletin-board-client-js/src/client/graphql-client.js
@@ -1,0 +1,120 @@
+import {
+  ApolloClient,
+  InMemoryCache,
+  HttpLink,
+  split,
+} from "@apollo/client/core";
+import { getMainDefinition } from "@apollo/client/utilities";
+import ActionCableLink from "graphql-ruby-client/dist/subscriptions/ActionCableLink";
+import ActionCable from "actioncable";
+import { map } from "rxjs/operators";
+
+import GET_ELECTION_LOG_ENTRIES from "./operations/get_election_log_entries";
+import SUBSCRIBE_TO_ELECTION_LOG from "./operations/subscribe_to_election_log";
+import PROCESS_KEY_CEREMONY_STEP from "./operations/process_key_ceremony_step";
+
+/**
+ * This is the Bulletin Board API client that will use Apollo's client to
+ * interact with our GraphQL schema using both http and websocket connections.
+ */
+export class GraphQLClient {
+  /**
+   * Initializes the class given the correct params. Since we need to handle
+   * both http and websocket connections we need to create two links and use either
+   * of them depending on the GraphQL operation.
+   *
+   * @constructor
+   * @param {Object} params - An object that include the following options.
+   *  - {String} apiEndpointUrl - The http endpoint used to perform queries and mutations.
+   *  - {String} wsEndpointUrl - The ws endpoint used to perform subscriptions.
+   *  - {Object?} headers - An optional object of headers to be included on http requests.
+   */
+  constructor({ apiEndpointUrl, wsEndpointUrl, headers }) {
+    const wsLink = new ActionCableLink({
+      cable: ActionCable.createConsumer(wsEndpointUrl),
+    });
+
+    const httpLink = new HttpLink({
+      uri: apiEndpointUrl,
+      headers,
+    });
+
+    const splitLink = split(
+      ({ query }) => {
+        const definition = getMainDefinition(query);
+        return (
+          definition.kind === "OperationDefinition" &&
+          definition.operation === "subscription"
+        );
+      },
+      wsLink,
+      httpLink
+    );
+
+    this.apolloClient = new ApolloClient({
+      link: splitLink,
+      cache: new InMemoryCache(),
+    });
+  }
+
+  /**
+   * Query all log entries for the given election id.
+   *
+   * @param {Object} params - An object that include the following options.
+   *  - {String} electionId - The election's id.
+   * @returns {Promise<Array<Object>>} - A collection of log entries.
+   * @throws Will throw an error if the request is rejected.
+   */
+  async getElectionLogEntries({ electionId }) {
+    const result = await this.apolloClient.query({
+      query: GET_ELECTION_LOG_ENTRIES,
+      variables: {
+        electionId,
+      },
+    });
+
+    return result.data.election.logEntries;
+  }
+
+  /**
+   * Returns an observable that needs to be manually subscribed and unsubscribed.
+   * When a new log entry is added it maps the GraphQL result to a log entry.
+   *
+   * @param {Object} params - An object that include the following options.
+   *  - {String} electionId - The election's id.
+   * @returns {Observable<Object>} - An observable that returns every log entry added.
+   */
+  subscribeToElectionLogEntriesUpdates({ electionId }) {
+    return this.apolloClient
+      .subscribe({
+        query: SUBSCRIBE_TO_ELECTION_LOG,
+        variables: {
+          electionId,
+        },
+      })
+      .pipe(map(({ data }) => data.electionLogEntryAdded.logEntry));
+  }
+
+  /**
+   * Process a key ceremony step sending a signed message.
+   *
+   * @param {Object} params - An object that include the following options.
+   *  - {String} electionId - The election's id.
+   * @returns {Promise<Object>} - A pending message created.
+   * @throws Will throw an error if the request is rejected or the data contains an error.
+   */
+  async processKeyCeremonyStep({ signedData }) {
+    const result = await this.apolloClient.mutate({
+      mutation: PROCESS_KEY_CEREMONY_STEP,
+      variables: {
+        signedData,
+      },
+    });
+
+    if (result.data.processKeyCeremonyStep.error) {
+      throw new Error(result.data.processKeyCeremonyStep.error);
+    }
+
+    return result.data.processKeyCeremonyStep.pendingMessage;
+  }
+}

--- a/decidim-bulletin-board-client-js/src/client/graphql-client.test.js
+++ b/decidim-bulletin-board-client-js/src/client/graphql-client.test.js
@@ -1,0 +1,97 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { GraphQLClient } from "./graphql-client";
+
+beforeEach(() => {
+  fetch.resetMocks();
+});
+
+describe("GraphQLClient", () => {
+  let client;
+
+  beforeEach(() => {
+    client = new GraphQLClient({
+      apiEndpointUrl: "https://example.org/api",
+      wsEndpointUrl: "wss://example.org/cable",
+    });
+  });
+
+  describe("getElectionLogEntries", () => {
+    it("returns all the log entries given a election id", async () => {
+      const logEntriesResult = [
+        { logType: "dummy.1", signedData: "1234" },
+        { logType: "dummy.2", signedData: "5678" },
+      ];
+
+      fetch.mockResponseOnce(
+        JSON.stringify({ data: { election: { logEntries: logEntriesResult } } })
+      );
+
+      const logEntries = await client.getElectionLogEntries({
+        electionId: "example.1",
+      });
+
+      expect(logEntries).toEqual(logEntriesResult);
+    });
+
+    it("throws an error if something went wrong", async () => {
+      fetch.mockReject(() => Promise.reject(new Error("something went wrong")));
+
+      await expect(
+        client.getElectionLogEntries({
+          electionId: "example.1",
+        })
+      ).rejects.toThrow("something went wrong");
+    });
+  });
+
+  describe("sendKeyCeremonyMessage", () => {
+    it("returns the pending message created if everything went ok", async () => {
+      const pendingMessageResult = { signedData: "1234" };
+
+      fetch.mockResponseOnce(
+        JSON.stringify({
+          data: {
+            processKeyCeremonyStep: { pendingMessage: pendingMessageResult },
+          },
+        })
+      );
+
+      const pendingMessage = await client.processKeyCeremonyStep({
+        electionId: "example.1",
+      });
+
+      expect(pendingMessage).toEqual(pendingMessageResult);
+    });
+
+    it("throws an error if the response include an error message", async () => {
+      const errorMessage = "message cannot be processed";
+
+      fetch.mockResponseOnce(
+        JSON.stringify({
+          data: {
+            processKeyCeremonyStep: { error: errorMessage },
+          },
+        })
+      );
+
+      await expect(
+        client.processKeyCeremonyStep({
+          electionId: "example.1",
+        })
+      ).rejects.toThrow(errorMessage);
+    });
+
+    it("throws an error if something went wrong", async () => {
+      fetch.mockReject(() => Promise.reject(new Error("something went wrong")));
+
+      await expect(
+        client.processKeyCeremonyStep({
+          electionId: "example.1",
+        })
+      ).rejects.toThrow("something went wrong");
+    });
+  });
+});

--- a/decidim-bulletin-board-client-js/src/client/operations/get_election_log_entries.gql
+++ b/decidim-bulletin-board-client-js/src/client/operations/get_election_log_entries.gql
@@ -1,0 +1,8 @@
+query GetElectionLogEntries($electionId: String!) {
+  election(id: $electionId) {
+    logEntries {
+      logType
+      signedData
+    }
+  }
+}

--- a/decidim-bulletin-board-client-js/src/client/operations/process_key_ceremony_step.gql
+++ b/decidim-bulletin-board-client-js/src/client/operations/process_key_ceremony_step.gql
@@ -1,0 +1,8 @@
+mutation ProcessKeyCeremonyStep($signedData: String!) {
+  processKeyCeremonyStep(signedData: $signedData) {
+    pendingMessage {
+      signedData
+    }
+    error
+  }
+}

--- a/decidim-bulletin-board-client-js/src/client/operations/subscribe_to_election_log.gql
+++ b/decidim-bulletin-board-client-js/src/client/operations/subscribe_to_election_log.gql
@@ -1,0 +1,8 @@
+subscription SubscribeToElectionLog($electionId: String!) {
+  electionLogEntryAdded(electionId: $electionId) {
+    logEntry {
+      logType
+      signedData
+    }
+  }
+}

--- a/decidim-bulletin-board-client-js/src/index.js
+++ b/decidim-bulletin-board-client-js/src/index.js
@@ -1,1 +1,3 @@
-export const hello = "world!";
+import { Client } from "./client/client";
+
+export { Client };

--- a/decidim-bulletin-board-client-js/src/index.test.js
+++ b/decidim-bulletin-board-client-js/src/index.test.js
@@ -1,3 +1,0 @@
-it("dummy test", () => {
-  expect(true).toBeTruthy();
-});

--- a/decidim-bulletin-board-client-js/src/setupTests.js
+++ b/decidim-bulletin-board-client-js/src/setupTests.js
@@ -1,0 +1,3 @@
+import fetchMock from "jest-fetch-mock";
+
+fetchMock.enableMocks();


### PR DESCRIPTION
This adds a new class `Client` to the package that will be used to interact with the GraphQL API in the Bulletin Board application. It can be used like this:

```js
import { Client } from "decidim-bulletin_board";
  
const bulletinBoardClient = new Client({
  apiEndpointUrl: "http://localhost:8000/api",
  wsEndpointUrl: "ws://localhost:8000/cable",
  headers: {
    Authorization: "some-token"
  }
});

bulletinBoardClient.getElectionLogEntries({ electionId: "dummy.1" });
```

The `Client` class is just a facade and it uses a `GraphQLClient` class that perform the operations to the GraphQL schema. I included some tests for both classes but at the moment the `GraphQLClient` just include some simple ones because it is a bit difficult to mock the websockets interactions.

This class will be used in upcoming PRs to perform the key ceremony.