### PR TITLE
feat(js): add KeyCeremony class

### DIFF
--- a/decidim-bulletin-board-client-js/package-lock.json
+++ b/decidim-bulletin-board-client-js/package-lock.json
@@ -6912,6 +6912,7 @@
       "version": "6.6.3",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
       "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
+      "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }

--- a/decidim-bulletin-board-client-js/package.json
+++ b/decidim-bulletin-board-client-js/package.json
@@ -17,14 +17,14 @@
     "@apollo/client": "^3.2.7",
     "actioncable": "^5.2.4-4",
     "graphql": "^15.4.0",
-    "graphql-ruby-client": "^1.8.1",
-    "rxjs": "^6.6.3"
+    "graphql-ruby-client": "^1.8.1"
   },
   "devDependencies": {
     "@babel/core": "^7.12.3",
     "@babel/preset-env": "^7.12.1",
     "babel-jest": "^26.6.3",
     "eslint": "^7.12.1",
+    "rxjs": "^6.6.3",
     "eslint-config-prettier": "^6.15.0",
     "eslint-config-standard": "^16.0.1",
     "eslint-plugin-import": "^2.22.1",

--- a/decidim-bulletin-board-client-js/src/client/client.js
+++ b/decidim-bulletin-board-client-js/src/client/client.js
@@ -39,7 +39,11 @@ export class Client {
       electionId,
     });
 
-    return subscription.subscribe(onNextLogEntryUpdate);
+    return subscription.subscribe((logEntry) => {
+      if (logEntry) {
+        onNextLogEntryUpdate(logEntry);
+      }
+    });
   }
 
   /**

--- a/decidim-bulletin-board-client-js/src/client/graphql-client.js
+++ b/decidim-bulletin-board-client-js/src/client/graphql-client.js
@@ -7,7 +7,6 @@ import {
 import { getMainDefinition } from "@apollo/client/utilities";
 import ActionCableLink from "graphql-ruby-client/dist/subscriptions/ActionCableLink";
 import ActionCable from "actioncable";
-import { map } from "rxjs/operators";
 
 import GET_ELECTION_LOG_ENTRIES from "./operations/get_election_log_entries";
 import SUBSCRIBE_TO_ELECTION_LOG from "./operations/subscribe_to_election_log";
@@ -92,7 +91,12 @@ export class GraphQLClient {
           electionId,
         },
       })
-      .pipe(map(({ data }) => data.electionLogEntryAdded.logEntry));
+      .map(
+        ({ data }) =>
+          data &&
+          data.electionLogEntryAdded &&
+          data.electionLogEntryAdded.logEntry
+      );
   }
 
   /**

--- a/decidim-bulletin-board-client-js/src/index.js
+++ b/decidim-bulletin-board-client-js/src/index.js
@@ -1,3 +1,4 @@
 import { Client } from "./client/client";
+import { KeyCeremony } from "./key-ceremony/key-ceremony";
 
-export { Client };
+export { Client, KeyCeremony };

--- a/decidim-bulletin-board-client-js/src/key-ceremony/key-ceremony.js
+++ b/decidim-bulletin-board-client-js/src/key-ceremony/key-ceremony.js
@@ -1,0 +1,141 @@
+import { Trustee } from "../trustee/trustee";
+
+export const WAIT_TIME_MS = 1_000; // 1s
+const DEFAULT_STATE = { message: null, done: false };
+
+/**
+ * Handles all the key ceremony steps for a specific election and trustee.
+ */
+export class KeyCeremony {
+  /**
+   * Initializes the class with the given params.
+   *
+   * @constructor
+   * @param {Object} params - An object that contains the initialization params.
+   *  - {Client} bulletinBoardClient - An instance of the Bulletin Board Client
+   *  - {Object} electionContext - An object that contains some necessary attributes
+   *                               of the election to perform the key ceremony.
+   *  - {Object?} options - An optional object with some options to configure the key ceremony.
+   */
+  constructor({ bulletinBoardClient, electionContext, options }) {
+    this.bulletinBoardClient = bulletinBoardClient;
+    this.electionContext = electionContext;
+    this.currentTrustee = null;
+    this.options = options || { bulletinBoardWaitTime: WAIT_TIME_MS };
+  }
+
+  /**
+   * Performs some operations to setup the key ceremony. Initializes the trustee
+   * object based on the given election context and subscribe to log entries updates.
+   *
+   * @returns {Promise<void>}
+   */
+  async setup() {
+    const { id: electionId, currentTrusteeContext } = this.electionContext;
+
+    this.currentTrustee = new Trustee(currentTrusteeContext);
+
+    this.electionLogEntries = await this.bulletinBoardClient.getElectionLogEntries(
+      {
+        electionId,
+      }
+    );
+
+    this.nextLogEntryIndexToProcess = 0;
+
+    this.subscription = this.bulletinBoardClient.subscribeToElectionLogEntriesUpdates(
+      {
+        electionId,
+      },
+      (logEntry) => {
+        this.electionLogEntries = [...this.electionLogEntries, logEntry];
+      }
+    );
+  }
+
+  /**
+   * Start the key ceremony with the default initial state. When the ceremony
+   * ends a final `Object`` is returned inside a `Promise` that contains the election key.
+   *
+   * @returns {Promise<Object>}
+   */
+  async run() {
+    return this.processNextStep(DEFAULT_STATE);
+  }
+
+  /**
+   * Receives the result of a log entry processed. It the key ceremony is done
+   * it just returns the final result. Otherwise it waits until another log entry is processed
+   * and calls itself again with the result.
+   *
+   * @private
+   * @param {Object} result - The result of the previous processed log entry.
+   * @returns {Promise<Object>}
+   */
+  async processNextStep({ message, done }) {
+    if (!done) {
+      return this.waitForNextLogEntryResult().then(async (result) => {
+        await this.sendMessageToBulletinBoard(result);
+        return this.processNextStep(result);
+      });
+    }
+    return message;
+  }
+
+  /**
+   * Creates a interval that will check periodically if there are new log entries
+   * to process. The interval is done when a new log entry is processed and it has
+   * a result.
+   *
+   * @private
+   * @returns {Promise<Object>}
+   */
+  waitForNextLogEntryResult() {
+    return new Promise((resolve) => {
+      const intervalId = setInterval(async () => {
+        let result;
+
+        if (this.electionLogEntries.length > this.nextLogEntryIndexToProcess) {
+          result = await this.processNextLogEntry();
+        }
+
+        if (result) {
+          clearInterval(intervalId);
+          resolve(result);
+        }
+      }, this.options.bulletinBoardWaitTime);
+    });
+  }
+
+  /**
+   * Uses the `Trustee` object to process the next log entry and outputs the result.
+   *
+   * @private
+   * @returns {Promise<Object|null>}
+   */
+  async processNextLogEntry() {
+    const result = await this.currentTrustee.processLogEntry(
+      this.electionLogEntries[this.nextLogEntryIndexToProcess]
+    );
+
+    this.nextLogEntryIndexToProcess += 1;
+
+    return result;
+  }
+
+  /**
+   * Sign a message using the `Trustee` identification keys and send it to the Bulletin Board.
+   *
+   * @private
+   * @param {Object} message - An object containing some data to be sent to the Bulletin Board.
+   * @returns <Promise<Object>}
+   * @throws An exception is raised if there is a problem with the client.
+   */
+  async sendMessageToBulletinBoard({ message }) {
+    const signedData = await this.currentTrustee.sign(message);
+
+    return this.bulletinBoardClient.processKeyCeremonyStep({
+      signedData,
+    });
+  }
+}

--- a/decidim-bulletin-board-client-js/src/key-ceremony/key-ceremony.test.js
+++ b/decidim-bulletin-board-client-js/src/key-ceremony/key-ceremony.test.js
@@ -1,0 +1,141 @@
+import { tap } from "rxjs/operators";
+import { Subject } from "rxjs";
+
+import { KeyCeremony } from "./key-ceremony";
+
+jest.mock("../trustee/trustee");
+
+describe("KeyCeremony", () => {
+  const electionLogEntriesUpdates = new Subject();
+
+  const bulletinBoardClient = {
+    getElectionLogEntries: jest.fn(() => Promise.resolve([])),
+    subscribeToElectionLogEntriesUpdates: jest.fn((_args, fn) =>
+      electionLogEntriesUpdates.pipe(tap(fn)).subscribe()
+    ),
+    processKeyCeremonyStep: jest.fn(),
+  };
+
+  const currentTrusteeContext = {
+    id: "trustee-1",
+    identificationKeys: {},
+  };
+
+  const electionContext = {
+    id: "election-1",
+    currentTrusteeContext,
+  };
+
+  const defaultParams = {
+    bulletinBoardClient,
+    electionContext,
+    options: {
+      bulletinBoardWaitTime: 0,
+    },
+  };
+
+  const buildKeyCeremony = (params = defaultParams) => {
+    return new KeyCeremony(params);
+  };
+
+  let keyCeremony;
+
+  beforeEach(async () => {
+    keyCeremony = buildKeyCeremony();
+  });
+
+  it("initialize the ceremony with the correct params", () => {
+    expect(keyCeremony.bulletinBoardClient).toEqual(
+      defaultParams.bulletinBoardClient
+    );
+    expect(keyCeremony.electionContext).toEqual(defaultParams.electionContext);
+    expect(keyCeremony.options).toEqual(defaultParams.options);
+  });
+
+  describe("setup", () => {
+    beforeEach(async () => {
+      await keyCeremony.setup();
+    });
+
+    it("query all the log entries for the given election context", () => {
+      expect(bulletinBoardClient.getElectionLogEntries).toHaveBeenCalledWith({
+        electionId: electionContext.id,
+      });
+      expect(keyCeremony.electionLogEntries.length).toEqual(0);
+    });
+
+    it("subscribe to the log entries updates for the given election context and stores them", () => {
+      expect(
+        bulletinBoardClient.subscribeToElectionLogEntriesUpdates
+      ).toHaveBeenCalledWith(
+        { electionId: electionContext.id },
+        expect.any(Function)
+      );
+
+      electionLogEntriesUpdates.next({ logType: "foo", signedData: "1234" });
+      electionLogEntriesUpdates.next({ logType: "foo", signedData: "5678" });
+      expect(keyCeremony.electionLogEntries.length).toEqual(2);
+    });
+  });
+
+  describe("run", () => {
+    beforeEach(async () => {
+      await keyCeremony.setup();
+    });
+
+    it("always processes the first log entry", async () => {
+      electionLogEntriesUpdates.next({
+        logType: "dummy.done",
+        signedData: "1234",
+      });
+      const result = await keyCeremony.run();
+      expect(bulletinBoardClient.processKeyCeremonyStep).toHaveBeenCalledWith({
+        signedData: "1234",
+      });
+      expect(result).toEqual({
+        signedData: "1234",
+      });
+    });
+
+    it("processes all messages until done", async () => {
+      electionLogEntriesUpdates.next({
+        logType: "dummy.step",
+        signedData: "1234",
+      });
+      electionLogEntriesUpdates.next({
+        logType: "dummy.done",
+        signedData: "5678",
+      });
+      const result = await keyCeremony.run();
+      expect(bulletinBoardClient.processKeyCeremonyStep).toHaveBeenCalledWith({
+        signedData: "1234",
+      });
+      expect(bulletinBoardClient.processKeyCeremonyStep).toHaveBeenCalledWith({
+        signedData: "5678",
+      });
+      expect(result).toEqual({
+        signedData: "5678",
+      });
+    });
+
+    it("skips the processed log entries that doesn't output a result", async () => {
+      electionLogEntriesUpdates.next({
+        logType: "dummy.nothing",
+        signedData: "1234",
+      });
+      electionLogEntriesUpdates.next({
+        logType: "dummy.done",
+        signedData: "5678",
+      });
+      const result = await keyCeremony.run();
+      expect(
+        bulletinBoardClient.processKeyCeremonyStep
+      ).not.toHaveBeenCalledWith({
+        signedData: "1234",
+      });
+      expect(result).toEqual({
+        signedData: "5678",
+      });
+    });
+  });
+});

--- a/decidim-bulletin-board-client-js/src/trustee/__mocks__/jwt_parser.js
+++ b/decidim-bulletin-board-client-js/src/trustee/__mocks__/jwt_parser.js
@@ -1,0 +1,5 @@
+export class JWTParser {
+  parse(signedData) {
+    return `${signedData} parsed`;
+  }
+}

--- a/decidim-bulletin-board-client-js/src/trustee/__mocks__/trustee.js
+++ b/decidim-bulletin-board-client-js/src/trustee/__mocks__/trustee.js
@@ -1,0 +1,29 @@
+export class Trustee {
+  processLogEntry({ logType, signedData }) {
+    switch (logType) {
+      case "dummy.nothing": {
+        return null;
+      }
+      case "dummy.step": {
+        return {
+          done: false,
+          message: {
+            signedData,
+          },
+        };
+      }
+      case "dummy.done": {
+        return {
+          done: true,
+          message: {
+            signedData,
+          },
+        };
+      }
+    }
+  }
+
+  sign({ signedData }) {
+    return signedData;
+  }
+}

--- a/decidim-bulletin-board-client-js/src/trustee/__mocks__/trustee_wrapper_dummy.js
+++ b/decidim-bulletin-board-client-js/src/trustee/__mocks__/trustee_wrapper_dummy.js
@@ -1,0 +1,7 @@
+export class TrusteeWrapper {
+  constructor({ trusteeId }) {
+    this.trusteeId = trusteeId;
+  }
+
+  processMessage() {}
+}

--- a/decidim-bulletin-board-client-js/src/trustee/jwt_parser.js
+++ b/decidim-bulletin-board-client-js/src/trustee/jwt_parser.js
@@ -1,0 +1,44 @@
+/**
+ * Verify and parses JWT tokens.
+ */
+export class JWTParser {
+  /**
+   * Parses the given token only if it can be verified.
+   *
+   * @param {String} token - A JWT token.
+   * @returns {Promise<Object>} - The payload included in the token.
+   * @throws An error is thrown if the payload is not a valid JSON or the token
+   *         cannot be verified.
+   */
+  async parse(token) {
+    const verified = await this.verify(token);
+
+    if (verified) {
+      const base64Url = token.split(".")[1];
+      const base64 = base64Url.replace(/-/g, "+").replace(/_/g, "/");
+      const jsonPayload = decodeURIComponent(
+        atob(base64)
+          .split("")
+          .map(function (c) {
+            return "%" + ("00" + c.charCodeAt(0).toString(16)).slice(-2);
+          })
+          .join("")
+      );
+
+      return JSON.parse(jsonPayload);
+    }
+
+    throw new Error(`${token} is not valid.`);
+  }
+
+  /**
+   * Verifies the token signature.
+   *
+   * @todo Needs real implementation.
+   * @param {String} token - A JWT token.
+   * @returns {Promise<Boolean>} - Whether the signature is valid or not.
+   */
+  verify(token) {
+    return Promise.resolve(true);
+  }
+}

--- a/decidim-bulletin-board-client-js/src/trustee/trustee.js
+++ b/decidim-bulletin-board-client-js/src/trustee/trustee.js
@@ -1,0 +1,46 @@
+import { TrusteeWrapper } from "./trustee_wrapper_dummy";
+import { JWTParser } from "./jwt_parser";
+
+/**
+ * This is a facade class that will use the correspondig `TrusteeWrapper` to process
+ * the log entries.
+ */
+export class Trustee {
+  /**
+   * Initializes the class with the given params.
+   *
+   * @constructor
+   * @param {Object} params - An object that contains the initialization params.
+   *  - {String} id - The trustee identifier.
+   *  - {Object} identificationKeys - A object that contains both the public and private key for
+   *                                  the corresponding trustee.
+   */
+  constructor({ id, identificationKeys }) {
+    this.id = id;
+    this.wrapper = new TrusteeWrapper({ trusteeId: id });
+    this.parser = new JWTParser();
+    this.identificationKeys = identificationKeys;
+  }
+
+  /**
+   * After parsing the `signedData` it processes the message using the wrapper.
+   *
+   * @param {Object} logEntry - The log entry to be processed.
+   * @returns {Promise<Object>} - The result of the processing if any.
+   */
+  async processLogEntry({ logType, signedData }) {
+    const payload = await this.parser.parse(signedData);
+    return this.wrapper.processMessage(logType, payload);
+  }
+
+  /**
+   * Delegates the sign process to the `identificationKeys`. It signs the
+   * message using the private key.
+   *
+   * @params {Object} message - The message to be signed.
+   * @returns {Promise<String>} - The signed message.
+   */
+  sign(message) {
+    return this.identificationKeys.sign(message);
+  }
+}

--- a/decidim-bulletin-board-client-js/src/trustee/trustee.test.js
+++ b/decidim-bulletin-board-client-js/src/trustee/trustee.test.js
@@ -1,0 +1,51 @@
+import { Trustee } from "./trustee";
+
+jest.mock("./trustee_wrapper_dummy");
+jest.mock("./jwt_parser");
+
+describe("Trustee", () => {
+  const identificationKeys = {
+    sign: jest.fn(),
+  };
+
+  const defaultParams = {
+    id: "trustee-1",
+    identificationKeys,
+  };
+
+  const buildTrustee = (params = defaultParams) => {
+    return new Trustee(params);
+  };
+
+  let trustee;
+
+  beforeEach(() => {
+    trustee = buildTrustee();
+  });
+
+  it("initialise the trustee wrapper with the given params", () => {
+    expect(trustee.id).toEqual(defaultParams.id);
+    expect(trustee.wrapper.trusteeId).toEqual(defaultParams.id);
+  });
+
+  describe("processLogEntry", () => {
+    it("calls the wrapper's process message method with the parsed data", async () => {
+      spyOn(trustee.wrapper, "processMessage");
+      await trustee.processLogEntry({
+        logType: "dummy",
+        signedData: "1234",
+      });
+      expect(trustee.wrapper.processMessage).toHaveBeenCalledWith(
+        "dummy",
+        "1234 parsed"
+      );
+    });
+  });
+
+  describe("sign", () => {
+    it("delegates to the provided `identificationKeys` object", () => {
+      trustee.sign({ foo: "bar" });
+      expect(identificationKeys.sign).toHaveBeenCalledWith({ foo: "bar" });
+    });
+  });
+});

--- a/decidim-bulletin-board-client-js/src/trustee/trustee_wrapper_dummy.js
+++ b/decidim-bulletin-board-client-js/src/trustee/trustee_wrapper_dummy.js
@@ -1,0 +1,66 @@
+export const CREATE_ELECTION = "create_election";
+export const KEY_CEREMONY = "key_ceremony";
+export const JOINT_ELECTION_KEY = "joint_election_key";
+
+/**
+ * This is just a dummy implementation of a possible `TrusteeWrapper`.
+ * It is based on the dummy voting schema that we are using in the Bulletin Board.
+ */
+export class TrusteeWrapper {
+  constructor({ trusteeId }) {
+    this.trusteeId = trusteeId;
+    this.status = CREATE_ELECTION;
+    this.electionId = null;
+    this.electionTrusteesCount = 0;
+    this.processedMessages = [];
+  }
+
+  processMessage(logType, message) {
+    switch (this.status) {
+      case CREATE_ELECTION: {
+        if (logType === CREATE_ELECTION) {
+          this.status = KEY_CEREMONY;
+          this.electionId = message.election_id;
+          this.processedMessages = [];
+          this.electionTrusteesCount = message.trustees.length;
+          return {
+            done: false,
+            message: {
+              iat: Math.round(+new Date() / 1000),
+              type: this.status,
+              election_id: this.electionId,
+              election_public_key: 7,
+              owner_id: this.trusteeId,
+            },
+          };
+        }
+        break;
+      }
+      case KEY_CEREMONY: {
+        if (logType === KEY_CEREMONY && message.owner_id !== this.trusteeId) {
+          this.processedMessages = [...this.processedMessages, message];
+          if (
+            this.processedMessages.length ===
+            this.electionTrusteesCount - 1
+          ) {
+            this.status = JOINT_ELECTION_KEY;
+            return {
+              done: false,
+              message: {},
+            };
+          }
+        }
+        break;
+      }
+      case JOINT_ELECTION_KEY: {
+        if (logType === JOINT_ELECTION_KEY) {
+          return {
+            done: true,
+            message,
+          };
+        }
+        break;
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds the `KeyCeremony` class that can be used to perform the key ceremony in `decidim`. It works like this:

```js
import { Client, KeyCeremony } from "decidim-bulletin_board";

const bulletinBoardClient = new Client({...});

const keyCeremony = new KeyCeremony({
  bulletinBoardClient,
  electionContext: {...}
});

// This is the current API and doesn't support notifications yet.
// Also this may change in upcoming PRs.
await keyCeremony.setup();
const result = await keyCeremony.run();
```

At the moment it only works with the dummy voting schema included in the Bulletin Board application and not exactly. I changed a few things in the current dummy schema but they are not included in this PR to simplify things.

I also left the JWT signature verification to another PR to make the review easier.