### PR TITLE
chore(app): allow AJAX requests from different domains

### DIFF
--- a/decidim-bulletin-board-app/Gemfile
+++ b/decidim-bulletin-board-app/Gemfile
@@ -36,6 +36,7 @@ gem "faker", "~> 1.9"
 gem "graphiql-rails"
 gem "jquery-rails"
 gem "jwt"
+gem "rack-cors"
 gem "rectify", "~> 0.13.0"
 gem "sprockets-es6"
 

--- a/decidim-bulletin-board-app/Gemfile.lock
+++ b/decidim-bulletin-board-app/Gemfile.lock
@@ -149,6 +149,8 @@ GEM
     puma (4.3.6)
       nio4r (~> 2.0)
     rack (2.2.3)
+    rack-cors (1.1.1)
+      rack (>= 2.0.0)
     rack-proxy (0.6.5)
       rack
     rack-test (1.1.0)
@@ -308,6 +310,7 @@ DEPENDENCIES
   pg (>= 0.18, < 2.0)
   pry-rails
   puma (~> 4.1)
+  rack-cors
   rails (~> 6.0.3, >= 6.0.3.2)
   rectify (~> 0.13.0)
   redcarpet

--- a/decidim-bulletin-board-app/config/initializers/cors.rb
+++ b/decidim-bulletin-board-app/config/initializers/cors.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+return if Rails.application.config.settings.cors_origin_allowed.blank?
+
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins "*"
+    resource "*", headers: :any, methods: [:get, :post, :patch, :put]
+  end
+end

--- a/decidim-bulletin-board-app/config/initializers/cors.rb
+++ b/decidim-bulletin-board-app/config/initializers/cors.rb
@@ -4,7 +4,7 @@ return if Rails.application.config.settings.cors_origin_allowed.blank?
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins "*"
+    origins Rails.application.config.settings.cors_origin_allowed
     resource "*", headers: :any, methods: [:get, :post, :patch, :put]
   end
 end

--- a/decidim-bulletin-board-app/config/settings.yml
+++ b/decidim-bulletin-board-app/config/settings.yml
@@ -1,8 +1,8 @@
-
 default: &default
   iat_expiration_minutes: 60
   create_election:
     hours_before: 2
+  cors_origin_allowed: "localhost:3000"
 
 development:
   <<: *default
@@ -12,3 +12,4 @@ test:
 
 production:
   <<: *default
+  cors_origin_allowed: <%= ENV["CORS_ORIGIN_ALLOWED"] %>


### PR DESCRIPTION
This adds the `rack-cors` gem to allow AJAX requests form a different domain. By default it only allows `localhost:3000` since it is the domain used for the `decidim` application in development.

In production environments a suitable domain must be provided using the `CORS_ORIGIN_ALLOWED` environment variable.