### PR TITLE
fix(app): store trustee ids in the scheme state

### DIFF
--- a/decidim-bulletin-board-app/app/commands/create_election.rb
+++ b/decidim-bulletin-board-app/app/commands/create_election.rb
@@ -65,7 +65,7 @@ class CreateElection < Rectify::Command
     Trustee.where(name: trustee["name"]).or(Trustee.where(public_key: trustee["public_key"])).first ||
       Trustee.create!(
         name: trustee["name"],
-        public_key: trustee["public_key"]
+        public_key: JSON.parse(trustee["public_key"])
       )
   end
 

--- a/decidim-bulletin-board-app/app/commands/process_key_ceremony_step.rb
+++ b/decidim-bulletin-board-app/app/commands/process_key_ceremony_step.rb
@@ -69,6 +69,7 @@ class ProcessKeyCeremonyStep < Rectify::Command
   def create_response_log_entry!
     return unless response_message
 
+    LogEntry.create!(
       election: election,
       signed_data: BulletinBoard.sign(response_message),
       log_type: response_message[:type],

--- a/decidim-bulletin-board-app/app/commands/process_key_ceremony_step.rb
+++ b/decidim-bulletin-board-app/app/commands/process_key_ceremony_step.rb
@@ -69,10 +69,9 @@ class ProcessKeyCeremonyStep < Rectify::Command
   def create_response_log_entry!
     return unless response_message
 
-    LogEntry.create!(
       election: election,
       signed_data: BulletinBoard.sign(response_message),
-      log_type: :key_ceremony,
+      log_type: response_message[:type],
       bulletin_board: true
     )
   end

--- a/decidim-bulletin-board-app/app/services/voting_scheme/dummy.rb
+++ b/decidim-bulletin-board-app/app/services/voting_scheme/dummy.rb
@@ -6,7 +6,7 @@ module VotingScheme
   # A dummy implementation of a voting scheme, only for tests purposes
   class Dummy < Base
     def initial_state
-      { joint_election_key: 1, trustees: 0 }
+      { joint_election_key: 1, trustees: [] }
     end
 
     def validate_election
@@ -23,11 +23,13 @@ module VotingScheme
     def process_key_ceremony_message(message)
       election_public_key = message.fetch("election_public_key", 0)
       raise RejectedMessage unless Prime.prime?(election_public_key)
+      owner_id = message.fetch("owner_id", nil)
+      raise RejectedMessage if owner_id.nil? || state[:trustees].include?(owner_id)
 
-      state[:trustees] += 1
+      state[:trustees] << owner_id
       state[:joint_election_key] *= election_public_key
 
-      if state[:trustees] == election.trustees.count
+      if state[:trustees].length == election.trustees.count
         election.status = :ready
         {
           type: :joint_election_key,

--- a/decidim-bulletin-board-app/app/services/voting_scheme/dummy.rb
+++ b/decidim-bulletin-board-app/app/services/voting_scheme/dummy.rb
@@ -23,6 +23,7 @@ module VotingScheme
     def process_key_ceremony_message(message)
       election_public_key = message.fetch("election_public_key", 0)
       raise RejectedMessage unless Prime.prime?(election_public_key)
+
       owner_id = message.fetch("owner_id", nil)
       raise RejectedMessage if owner_id.nil? || state[:trustees].include?(owner_id)
 

--- a/decidim-bulletin-board-app/spec/commands/process_key_ceremony_step_spec.rb
+++ b/decidim-bulletin-board-app/spec/commands/process_key_ceremony_step_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe ProcessKeyCeremonyStep do
   end
 
   context "when the voting scheme generates an answer" do
-    let(:voting_scheme_state) { Marshal.dump(trustees: trustees_plus_keys.size - 1, joint_election_key: 1) }
+    let(:voting_scheme_state) { Marshal.dump(trustees: (1..(trustees_plus_keys.size - 1)).to_a, joint_election_key: 1) }
 
     it "broadcast the election for the message" do
       expect { subject }.to broadcast(:election, election)


### PR DESCRIPTION
This changes the `Dummy` voting scheme to store the trustee ids so it only returns the final message when all trustees have sent their keys.

It also fixes a minor 🐛 bug when the trustee public keys were not stored as JSON objects. This caused an issue while decoding the data.