### PR TITLE
feat: add key ceremony events observable

### DIFF
--- a/decidim-bulletin_board-js/package-lock.json
+++ b/decidim-bulletin_board-js/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "decidim-bulletin-board",
+  "name": "decidim-bulletin_board",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/decidim-bulletin_board-js/src/index.test.js
+++ b/decidim-bulletin_board-js/src/index.test.js
@@ -1,3 +1,0 @@
-it("dummy test", () => {
-  expect(true).toBeTruthy();
-});

--- a/decidim-bulletin_board-js/src/key-ceremony/key-ceremony.js
+++ b/decidim-bulletin_board-js/src/key-ceremony/key-ceremony.js
@@ -31,13 +31,16 @@ export class KeyCeremony {
    * @returns {Promise<void>}
    */
   async setup() {
-    const { id: electionId, currentTrusteeContext } = this.electionContext;
+    const {
+      id: electionUniqueId,
+      currentTrusteeContext,
+    } = this.electionContext;
 
     this.currentTrustee = new Trustee(currentTrusteeContext);
 
     this.electionLogEntries = await this.bulletinBoardClient.getElectionLogEntries(
       {
-        electionId,
+        electionUniqueId,
       }
     );
 
@@ -45,7 +48,7 @@ export class KeyCeremony {
 
     this.subscription = this.bulletinBoardClient.subscribeToElectionLogEntriesUpdates(
       {
-        electionId,
+        electionUniqueId,
       },
       (logEntry) => {
         this.electionLogEntries = [...this.electionLogEntries, logEntry];

--- a/decidim-bulletin_board-js/src/key-ceremony/key-ceremony.test.js
+++ b/decidim-bulletin_board-js/src/key-ceremony/key-ceremony.test.js
@@ -59,7 +59,7 @@ describe("KeyCeremony", () => {
 
     it("query all the log entries for the given election context", () => {
       expect(bulletinBoardClient.getElectionLogEntries).toHaveBeenCalledWith({
-        electionId: electionContext.id,
+        electionUniqueId: electionContext.id,
       });
       expect(keyCeremony.electionLogEntries.length).toEqual(0);
     });
@@ -68,7 +68,7 @@ describe("KeyCeremony", () => {
       expect(
         bulletinBoardClient.subscribeToElectionLogEntriesUpdates
       ).toHaveBeenCalledWith(
-        { electionId: electionContext.id },
+        { electionUniqueId: electionContext.id },
         expect.any(Function)
       );
 


### PR DESCRIPTION
This adds a simple `events` observable to the `KeyCeremony` class. As a user of the library now I can do this:

```js
const keyCeremony = new KeyCeremony(...);

keyCeremony.events.subscribe(event => {
  // do something with the event
});
```

At the moment there are just two events supported: `MESSAGE_RECEIVED` and `MESSAGE_PROCESSED`. These two events can be exported from the key ceremony module as well:

```js
const { MESSAGE_RECEIVED, MESSAGE_PROCESSED } = decidimBulletinBoard.KeyCeremony;
```

This can be useful to update the UI accordingly in case you are expecting some messages to be processed.