### PR TITLE
Add vote endpoint

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -18,13 +18,3 @@ RUN gem install bundler
 
 # Install Yarn
 RUN curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.22.10
-
-# [Optional] Uncomment this section to install additional OS packages.
-# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-#     && apt-get -y install --no-install-recommends <your-package-list-here>
-
-# [Optional] Uncomment this line to install additional gems.
-# RUN gem install <your-gem-names-here>
-
-# [Optional] Uncomment this line to install global node packages.
-# RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,8 @@
 
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
-		"rebornix.Ruby"
+		"rebornix.Ruby",
+		"donjayamanne.githistory"
 	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/decidim-bulletin_board-app/app/commands/concerns/has_message_identifier.rb
+++ b/decidim-bulletin_board-app/app/commands/concerns/has_message_identifier.rb
@@ -12,5 +12,9 @@ module HasMessageIdentifier
     def message_identifier
       @message_identifier ||= MessageIdentifier.new(message_id)
     end
+
+    def election
+      @election ||= Election.find_by(unique_id: message_identifier.election_id)
+    end
   end
 end

--- a/decidim-bulletin_board-app/app/commands/concerns/log_entry_command.rb
+++ b/decidim-bulletin_board-app/app/commands/concerns/log_entry_command.rb
@@ -8,14 +8,14 @@ module LogEntryCommand
   included do
     include HasMessageIdentifier
 
-    attr_accessor :client, :signed_data, :log_entry, :error, :response_message
+    attr_accessor :client, :signed_data, :error, :response_message
     delegate :voting_scheme, to: :election
     delegate :decoded_data, to: :log_entry
 
     private
 
-    def build_log_entry
-      @log_entry = LogEntry.new(
+    def log_entry
+      @log_entry ||= LogEntry.new(
         message_id: message_id,
         signed_data: signed_data,
         client: client

--- a/decidim-bulletin_board-app/app/commands/create_election.rb
+++ b/decidim-bulletin_board-app/app/commands/create_election.rb
@@ -22,8 +22,6 @@ class CreateElection < Rectify::Command
   #
   # Returns nothing.
   def call
-    build_log_entry
-
     return broadcast(:invalid, error) unless
       valid_log_entry?("create_election") &&
       valid_step?(election.new_record?) &&

--- a/decidim-bulletin_board-app/app/commands/enqueue_message.rb
+++ b/decidim-bulletin_board-app/app/commands/enqueue_message.rb
@@ -38,12 +38,13 @@ class EnqueueMessage < Rectify::Command
   attr_reader :client, :signed_data, :job, :pending_message
 
   def valid?
-    client && message_id && signed_data && job
+    client && election && message_id && signed_data && job
   end
 
   def create_pending_message!
     @pending_message = PendingMessage.create!(
       client: client,
+      election: election,
       message_id: message_id,
       signed_data: signed_data,
       status: :enqueued

--- a/decidim-bulletin_board-app/app/commands/process_key_ceremony_step.rb
+++ b/decidim-bulletin_board-app/app/commands/process_key_ceremony_step.rb
@@ -17,20 +17,15 @@ class ProcessKeyCeremonyStep < Rectify::Command
 
   # Executes the command. Broadcasts these events:
   #
-  # - :election with the election model referred by the message
   # - :processed when everything is valid.
   # - :invalid if the received data wasn't valid.
   #
   # Returns nothing.
   def call
-    build_log_entry
-
     return broadcast(:invalid, error) unless
       valid_log_entry?("key_ceremony")
 
     election.with_lock do
-      broadcast(:election, election)
-
       return broadcast(:invalid, error) unless
         valid_step?(election.key_ceremony?) &&
         process_message
@@ -41,7 +36,7 @@ class ProcessKeyCeremonyStep < Rectify::Command
       election.save!
     end
 
-    broadcast(:processed)
+    broadcast(:ok)
   end
 
   private
@@ -57,9 +52,5 @@ class ProcessKeyCeremonyStep < Rectify::Command
       signed_data: BulletinBoard.sign(response_message),
       bulletin_board: true
     )
-  end
-
-  def election
-    @election ||= Election.find_by(unique_id: message_identifier.election_id)
   end
 end

--- a/decidim-bulletin_board-app/app/commands/vote.rb
+++ b/decidim-bulletin_board-app/app/commands/vote.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# A command with all the business logic to process a vote message
+class Vote < Rectify::Command
+  include LogEntryCommand
+
+  # Public: Initializes the command.
+  #
+  # authority - The authority sender of the vote message
+  # message_id - The message identifier
+  # signed_data - The signed message received
+  def initialize(authority, message_id, signed_data)
+    @client = @authority = authority
+    @message_id = message_id
+    @signed_data = signed_data
+  end
+
+  # Executes the command. Broadcasts these events:
+  #
+  # - :processed when everything is valid.
+  # - :invalid if the received data wasn't valid.
+  #
+  # Returns nothing.
+  def call
+    return broadcast(:invalid, error) unless
+      valid_log_entry?("vote")
+
+    return broadcast(:invalid, error) unless
+      valid_step?(election.vote?) &&
+      process_message
+
+    election.log_entries << log_entry
+    election.with_lock { log_entry.save! }
+
+    broadcast(:ok)
+  end
+
+  private
+
+  attr_accessor :authority
+end

--- a/decidim-bulletin_board-app/app/controllers/graphql_controller.rb
+++ b/decidim-bulletin_board-app/app/controllers/graphql_controller.rb
@@ -15,7 +15,7 @@ class GraphqlController < ApplicationController
 
     headers = variables.delete(:headers) || {}
     context = {
-      token: request.headers["Authorization"] || headers["Authorization"]
+      api_key: request.headers["Authorization"] || headers["Authorization"]
     }
 
     result = DecidimBulletinBoardSchema.execute(query, variables: variables, context: context, operation_name: operation_name)

--- a/decidim-bulletin_board-app/app/graphql/mutations/base_mutation.rb
+++ b/decidim-bulletin_board-app/app/graphql/mutations/base_mutation.rb
@@ -1,10 +1,18 @@
 # frozen_string_literal: true
 
+require "message_identifier"
+
 module Mutations
-  class BaseMutation < GraphQL::Schema::RelayClassicMutation
-    argument_class Types::BaseArgument
-    field_class Types::BaseField
-    input_object_class Types::BaseInputObject
-    object_class Types::BaseObject
+  class BaseMutation < GraphQL::Schema::Mutation
+    def find_authority(message_id)
+      message_identifier = MessageIdentifier.new(message_id)
+      message_identifier.from_authority? && Authority.find_by(unique_id: message_identifier.author_id, api_key: context[:api_key]) ||
+        message_identifier.from_voter? && Authority.find_by(api_key: context[:api_key])
+    end
+
+    def find_trustee(message_id)
+      message_identifier = MessageIdentifier.new(message_id)
+      message_identifier.from_trustee? && Trustee.find_by(unique_id: message_identifier.author_id)
+    end
   end
 end

--- a/decidim-bulletin_board-app/app/graphql/mutations/create_election_mutation.rb
+++ b/decidim-bulletin_board-app/app/graphql/mutations/create_election_mutation.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
-require "message_identifier"
-
 module Mutations
-  class CreateElectionMutation < GraphQL::Schema::Mutation
+  class CreateElectionMutation < BaseMutation
     argument :message_id, String, required: true
     argument :signed_data, String, required: true
 
@@ -27,13 +25,6 @@ module Mutations
       end
 
       result
-    end
-
-    private
-
-    def find_authority(message_id)
-      message_identifier = MessageIdentifier.new(message_id)
-      message_identifier.from_authority? && Authority.find_by(unique_id: message_identifier.author_id, api_key: context[:token])
     end
   end
 end

--- a/decidim-bulletin_board-app/app/graphql/mutations/process_key_ceremony_step_mutation.rb
+++ b/decidim-bulletin_board-app/app/graphql/mutations/process_key_ceremony_step_mutation.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
-require "message_identifier"
-
 module Mutations
-  class ProcessKeyCeremonyStepMutation < GraphQL::Schema::Mutation
+  class ProcessKeyCeremonyStepMutation < BaseMutation
     argument :message_id, String, required: true
     argument :signed_data, String, required: true
 
@@ -24,13 +22,6 @@ module Mutations
       end
 
       result
-    end
-
-    private
-
-    def find_trustee(message_id)
-      message_identifier = MessageIdentifier.new(message_id)
-      message_identifier.from_trustee? && Trustee.find_by(unique_id: message_identifier.author_id)
     end
   end
 end

--- a/decidim-bulletin_board-app/app/graphql/mutations/vote_mutation.rb
+++ b/decidim-bulletin_board-app/app/graphql/mutations/vote_mutation.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Mutations
+  class VoteMutation < BaseMutation
+    argument :message_id, String, required: true
+    argument :signed_data, String, required: true
+
+    field :pending_message, Types::PendingMessageType, null: true
+    field :error, String, null: true
+
+    def resolve(message_id:, signed_data:)
+      authority = find_authority(message_id)
+
+      return { error: "Authority not found" } unless authority
+
+      result = { error: "There was an error creating the election." }
+
+      EnqueueMessage.call(authority, message_id, signed_data, VoteJob) do
+        on(:ok) do |pending_message|
+          result = { pending_message: pending_message }
+        end
+      end
+
+      result
+    end
+  end
+end

--- a/decidim-bulletin_board-app/app/graphql/types/mutation_type.rb
+++ b/decidim-bulletin_board-app/app/graphql/types/mutation_type.rb
@@ -4,5 +4,6 @@ module Types
   class MutationType < Types::BaseObject
     field :create_election, mutation: Mutations::CreateElectionMutation
     field :process_key_ceremony_step, mutation: Mutations::ProcessKeyCeremonyStepMutation
+    field :vote, mutation: Mutations::VoteMutation
   end
 end

--- a/decidim-bulletin_board-app/app/jobs/application_job.rb
+++ b/decidim-bulletin_board-app/app/jobs/application_job.rb
@@ -6,4 +6,6 @@ class ApplicationJob < ActiveJob::Base
 
   # Most jobs are safe to ignore if the underlying records are no longer available
   # discard_on ActiveJob::DeserializationError
+
+  class MessageNotProcessed < StandardError; end
 end

--- a/decidim-bulletin_board-app/app/jobs/process_key_ceremony_step_job.rb
+++ b/decidim-bulletin_board-app/app/jobs/process_key_ceremony_step_job.rb
@@ -10,11 +10,8 @@ class ProcessKeyCeremonyStepJob < ApplicationJob
       next unless pending_message.enqueued?
 
       ProcessKeyCeremonyStep.call(pending_message.client, pending_message.message_id, pending_message.signed_data) do
-        on(:election) { |election| pending_message.election = election }
-        on(:processed) { |_result| pending_message.status = :accepted }
-        on(:invalid) do |_result, _message|
-          pending_message.status = :rejected
-        end
+        on(:ok) { |_result| pending_message.status = :accepted }
+        on(:invalid) { |_result, _message| pending_message.status = :rejected }
       end
 
       raise MessageNotProcessed unless pending_message.processed?

--- a/decidim-bulletin_board-app/app/jobs/process_key_ceremony_step_job.rb
+++ b/decidim-bulletin_board-app/app/jobs/process_key_ceremony_step_job.rb
@@ -23,5 +23,3 @@ class ProcessKeyCeremonyStepJob < ApplicationJob
     end
   end
 end
-
-class MessageNotProcessed < StandardError; end

--- a/decidim-bulletin_board-app/app/jobs/vote_job.rb
+++ b/decidim-bulletin_board-app/app/jobs/vote_job.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class VoteJob < ApplicationJob
+  queue_as :vote
+
+  def perform(pending_message_id)
+    pending_message = PendingMessage.find(pending_message_id)
+
+    pending_message.with_lock do
+      next unless pending_message.enqueued?
+
+      Vote.call(pending_message.client, pending_message.message_id, pending_message.signed_data) do
+        on(:ok) { |_result| pending_message.status = :accepted }
+        on(:invalid) { |_result, _message| pending_message.status = :rejected }
+      end
+
+      raise MessageNotProcessed unless pending_message.processed?
+
+      pending_message.save!
+    end
+  end
+end

--- a/decidim-bulletin_board-app/app/models/pending_message.rb
+++ b/decidim-bulletin_board-app/app/models/pending_message.rb
@@ -2,11 +2,11 @@
 
 class PendingMessage < ApplicationRecord
   belongs_to :client
-  belongs_to :election, optional: true
+  belongs_to :election
 
   enum status: [:enqueued, :rejected, :accepted].map { |status| [status, status.to_s] }.to_h
 
   def processed?
-    (accepted? && election) || rejected?
+    accepted? || rejected?
   end
 end

--- a/decidim-bulletin_board-app/app/services/voting_scheme/dummy.rb
+++ b/decidim-bulletin_board-app/app/services/voting_scheme/dummy.rb
@@ -40,5 +40,9 @@ module VotingScheme
                       "joint_election_key" => state[:joint_election_key]
       end
     end
+
+    def process_vote_message(message)
+      raise RejectedMessage, "The given ballot style is invalid" if message.fetch("ballot_style", "invalid-style") == "invalid-style"
+    end
   end
 end

--- a/decidim-bulletin_board-app/app/services/voting_scheme/dummy.rb
+++ b/decidim-bulletin_board-app/app/services/voting_scheme/dummy.rb
@@ -5,18 +5,25 @@ require "prime"
 module VotingScheme
   # A dummy implementation of a voting scheme, only for tests purposes
   class Dummy < Base
-    def process_message(message_id, message)
-      method_name = :"process_#{message_id.type}_message"
-      method(method_name).call(message) if respond_to?(method_name, true)
+    def process_message(message_identifier, message)
+      method_name = :"process_#{message_identifier.type}_message"
+      if respond_to?(method_name, true)
+        @response = nil
+        method(method_name).call(message)
+        @response
+      end
     end
 
     private
+
+    def emit_response(response)
+      @response = response
+    end
 
     def process_create_election_message(message)
       raise RejectedMessage, "There must be at least 2 Trustees" if message.fetch("trustees", []).count < 2
 
       @state = { joint_election_key: 1, trustees: [] }
-      nil
     end
 
     def process_key_ceremony_message(message)
@@ -29,10 +36,8 @@ module VotingScheme
 
       if state[:trustees].count == election.trustees.count
         election.status = :ready
-        {
-          "message_id" => "#{election.unique_id}.key_ceremony.joint_election_key+b.#{BulletinBoard.unique_id}",
-          "joint_election_key" => state[:joint_election_key]
-        }
+        emit_response "message_id" => "#{election.unique_id}.key_ceremony.joint_election_key+b.#{BulletinBoard.unique_id}",
+                      "joint_election_key" => state[:joint_election_key]
       end
     end
   end

--- a/decidim-bulletin_board-app/db/migrate/20201201141644_change_pending_messages_election_null.rb
+++ b/decidim-bulletin_board-app/db/migrate/20201201141644_change_pending_messages_election_null.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ChangePendingMessagesElectionNull < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null :pending_messages, :election_id, false
+  end
+end

--- a/decidim-bulletin_board-app/db/schema.rb
+++ b/decidim-bulletin_board-app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_17_095739) do
+ActiveRecord::Schema.define(version: 2020_12_01_141644) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -66,7 +66,7 @@ ActiveRecord::Schema.define(version: 2020_11_17_095739) do
   end
 
   create_table "pending_messages", force: :cascade do |t|
-    t.bigint "election_id"
+    t.bigint "election_id", null: false
     t.bigint "client_id", null: false
     t.text "signed_data", null: false
     t.string "status", default: "0", null: false

--- a/decidim-bulletin_board-app/lib/message_identifier.rb
+++ b/decidim-bulletin_board-app/lib/message_identifier.rb
@@ -13,6 +13,10 @@ class MessageIdentifier
     author_type == :trustee
   end
 
+  def from_voter?
+    author_type == :voter
+  end
+
   def author_type
     @author_type ||= AUTHOR_TYPE[author.first.to_sym]
   end

--- a/decidim-bulletin_board-app/spec/commands/enqueue_message_spec.rb
+++ b/decidim-bulletin_board-app/spec/commands/enqueue_message_spec.rb
@@ -24,6 +24,11 @@ RSpec.describe EnqueueMessage do
     expect(PendingMessage.last.client).to eq(client)
   end
 
+  it "stores the message election" do
+    subject
+    expect(PendingMessage.last.election).to eq(election)
+  end
+
   it "stores the message identifier" do
     subject
     expect(PendingMessage.last.message_id).to eq(message_id)

--- a/decidim-bulletin_board-app/spec/commands/process_key_ceremony_step_spec.rb
+++ b/decidim-bulletin_board-app/spec/commands/process_key_ceremony_step_spec.rb
@@ -22,12 +22,8 @@ RSpec.describe ProcessKeyCeremonyStep do
   let(:message_type) { :key_ceremony_message }
   let(:message_params) { { election: election, trustee: trustee } }
 
-  it "broadcast the election for the message" do
-    expect { subject }.to broadcast(:election, election)
-  end
-
-  it "broadcast processed" do
-    expect { subject }.to broadcast(:processed)
+  it "broadcast ok" do
+    expect { subject }.to broadcast(:ok)
   end
 
   it "creates the log entry for the message" do
@@ -45,12 +41,8 @@ RSpec.describe ProcessKeyCeremonyStep do
   context "when the voting scheme generates an answer" do
     let(:public_keys_already_sent) { trustees_plus_keys.map(&:first).excluding(trustee) }
 
-    it "broadcast the election for the message" do
-      expect { subject }.to broadcast(:election, election)
-    end
-
-    it "broadcast processed" do
-      expect { subject }.to broadcast(:processed)
+    it "broadcast ok" do
+      expect { subject }.to broadcast(:ok)
     end
 
     it "creates the log entry for the message and another for the response" do

--- a/decidim-bulletin_board-app/spec/commands/vote_spec.rb
+++ b/decidim-bulletin_board-app/spec/commands/vote_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "./spec/commands/shared/log_entry_validations"
+
+RSpec.describe Vote do
+  subject { described_class.call(authority, message_id, signed_data) }
+
+  include_context "with a signed message"
+
+  let!(:election) { create(:election, status: election_status) }
+  let(:election_status) { :vote }
+  let(:authority) { create(:authority, private_key: private_key) }
+  let(:message_type) { :vote_message }
+  let(:message_params) { { election: election, authority: authority } }
+
+  it "broadcast ok" do
+    expect { subject }.to broadcast(:ok)
+  end
+
+  it "creates the log entry for the message" do
+    expect { subject }.to change(LogEntry, :count).by(1)
+  end
+
+  it "doesn't change the election voting scheme state" do
+    expect { subject }.not_to(change { Election.last.voting_scheme_state })
+  end
+
+  it "doesn't change the election status" do
+    expect { subject }.not_to change { Election.last.status } .from("vote")
+  end
+
+  context "when the vote message is invalid" do
+    let(:extra_message_params) { { ballot_style: "invalid-style" } }
+
+    it "broadcast invalid" do
+      expect { subject }.to broadcast(:invalid)
+    end
+
+    it "doesn't create the log entry for the message" do
+      expect { subject }.not_to change(LogEntry, :count)
+    end
+
+    it "doesn't change the election voting scheme state" do
+      expect { subject }.not_to(change { Election.last.voting_scheme_state })
+    end
+
+    it "doesn't change the election status" do
+      expect { subject }.not_to change { Election.last.status } .from("vote")
+    end
+  end
+end

--- a/decidim-bulletin_board-app/spec/factories/messages.rb
+++ b/decidim-bulletin_board-app/spec/factories/messages.rb
@@ -171,7 +171,7 @@ FactoryBot.define do
       end
 
       message_id { "#{election.unique_id}.vote.cast+v.#{_object_id}" }
-      ballot_style { 'ballot-style' }
+      ballot_style { "ballot-style" }
       contests { build_list(:contest_ballot, number_of_questions) }
       _object_id { generate(:voter_id) }
       previous_tracking_hash { "" }

--- a/decidim-bulletin_board-app/spec/factories/messages.rb
+++ b/decidim-bulletin_board-app/spec/factories/messages.rb
@@ -18,6 +18,10 @@ FactoryBot.define do
     "selection-#{n}"
   end
 
+  sequence(:voter_id) do |n|
+    "voter-#{n}"
+  end
+
   factory :json, class: "ActiveSupport::HashWithIndifferentAccess" do
     initialize_with { ActiveSupport::HashWithIndifferentAccess[**fix_reserved_names(attributes)] }
     skip_create
@@ -74,26 +78,30 @@ FactoryBot.define do
       start_date { 1.week.from_now }
       end_date { 2.weeks.from_now }
       candidates { [] }
-      contests { build_list(:contest, number_of_questions) }
+      contests { build_list(:contest_description, number_of_questions) }
 
       after(:build) do |description|
         description[:contests].each_with_index do |contest, contest_order|
           contest[:sequence_order] = contest_order
           contest[:ballot_selections].each_with_index do |ballot_selection, selection_order|
             ballot_selection[:sequence_order] = selection_order
-            description[:candidates] << build(:candidate, _object_id: ballot_selection[:candidate_id])
+            description[:candidates] << build(:candidate_description, _object_id: ballot_selection[:candidate_id])
           end
         end
         [:start_date, :end_date].each { |field| description[field] = description[field].iso8601 }
       end
     end
 
-    factory :candidate do
+    factory :candidate_description do
       _object_id { generate(:candidate_id) }
       ballot_name { build(:text) }
     end
 
-    factory :contest do
+    factory :contest_description do
+      transient do
+        number_of_answers { 2 }
+      end
+
       type { "ReferendumContest" }
       _object_id { generate(:contest_id) }
       sequence_order { 0 }
@@ -103,7 +111,7 @@ FactoryBot.define do
       minimum_elected { 1 }
       ballot_title { build(:text) }
       ballot_subtitle { build(:text) }
-      ballot_selections { build_list(:ballot_selection, 2, contest_id: _object_id) }
+      ballot_selections { build_list(:selection_description, number_of_answers, contest_id: _object_id) }
     end
 
     factory :text do
@@ -119,7 +127,7 @@ FactoryBot.define do
       language { "en" }
     end
 
-    factory :ballot_selection do
+    factory :selection_description do
       transient do
         contest_id { generate(:contest_id) }
       end
@@ -154,6 +162,81 @@ FactoryBot.define do
       public_key { "UxmYOgII7XfkqtmIhkm2I3W5g83recLynlu+z6qK9/iSyB1hW+H7j7KpKnd+pLAOCnxrKA7Kglxk4x5jQdXfYRhiTkL9TzIhejVoXpFFEqH8I1+8mPCYMPY1GxBhZodbAl3CRSIRqS7IMQfFZ6gtZFjrij5P70SuXYyI+K2igVcQuG1BK8CKFXpzDxiKhbVltIjNk4un8K48lTkNqH+nyJ+GQiBUi+x2/gGxgF6naQO9Z/ZAgTcECf9J7LnPxY/0iFkAyJsQiyDpktPCVfy5aAfUYwbDxatIIoE7ujKXyxrbEHPu+VtX3GvLRb53kPp8Wuh3b8eDSagwmh4Fa/yHpcfq1CJSGT4C4K55VbtQ1PcMTQyGJEtgBjpU/3XGyLK1TarnmFlZonKRiuYhHMLKmj4E1F5jaJ12/AwS+jXjTASZwMHgVdflkMCH/rceutcLTKtISNtZdGmP9JcnQ1uOCr1EQe/2sTlz1M8YzvupoPtBUE9ZtgvxGzPKx+tldJQv1cqVsAYTmEL3McUFeK3YLa5819kAOdZ/1tGy3pk3mIRdbiD1GFyiW3MEOwEAKVikIxninC0TwIw0ZiKh5C6YP3mOTN2C8zmWle1uPihO7XLK0f4TKC0pyCMXklkyZa05ZmjWgctJ17RWjLE1boNVTFwFOmy3ASErzDGbJtu9g8A=" }
       response { "puH3SmTJnSn4JL3uDM5exiB0mDa67vibiu3qkA8IbCM" }
       usage { "SecretValue" }
+    end
+
+    factory :vote_message, parent: :message do
+      transient do
+        election { build(:election) }
+        number_of_questions { 2 }
+      end
+
+      message_id { "#{election.unique_id}.vote.cast+v.#{_object_id}" }
+      ballot_style { 'ballot-style' }
+      contests { build_list(:contest_ballot, number_of_questions) }
+      _object_id { generate(:voter_id) }
+      previous_tracking_hash { "" }
+      timestamp { Time.current.to_i }
+      crypto_hash { "bjISpYYhG+uthocLKA5wjOFdHPVo34xby8vz3RWj7BY=" }
+      description_hash { "7dS66G9hBgVu+fIrx61sJDCECgU9UIawwy+RWi8xR9s=" }
+      tracking_hash { "Cq6aF8l4dDCtuaptvyZ+Ej+Cep90CPPysVH4orucwoY=" }
+
+      trait :invalid do
+        ballot_style { "invalid-style" }
+      end
+    end
+
+    factory :contest_ballot do
+      transient do
+        number_of_answers { 2 }
+      end
+
+      ballot_selections { build_list(:selection_ballot, number_of_answers, contest_id: _object_id) }
+      crypto_hash { "INc1UrKLWxwaVjup1Vv+nW4GCdWsb1+hNGzlBeZpRUI=" }
+      description_hash { "zRhfoa+0QfJYxeAyBST7TF7+ApGlwQUyGifvlT798/0=" }
+      _object_id { generate(:contest_id) }
+      proof { build(:contest_proof) }
+    end
+
+    factory :contest_proof do
+      challenge { "1A1ZjlenxRKLSf6o0to2+fVkGoAIl4Z5DQSV4691GfI=" }
+      constant { 1 }
+      data { "/bB0vydnOyyn2KgsH0QmGvffhDv2X2cD92DQ1ZDnJbgjjfeDNRkv0DGGDYHuatLsXcdcEkH00PFvr92SrLOuqRK5ar4x1PMaAbReqzOn7khNnS64zOI+abiyefg704zPWDb73Mmp8VdAY0M+Z/zxGmMgvIqNannGK+bd55CND7l8KgIfkOLhqyKqtL72uH4fbZjivfpHG1Z2hV/JtaSou3HoET50+4A5JkwzgrMdMPNO/AOO7KixcOYNUZNu/AU4pW0S0R8/W3aSgLnEHPt2bC3WHlhPskjn4Q9G2cJBnhOBoJ1QM3hkDKx/FnBBpkcWLEuq98rFUXrYxrQiJNHBdbTKk30EAYc+K1JHiIkmhodmQ/tjCRR2YPgVgjnlrByHgZU6jkO2UZ16eGXrJx9EfG7+J02/69qE5BOoWCYae14WlR+2ZMjC80XqgNtcrjpgU2Oq+yOUpFshLkuHf5DXraDmF4VStK7uYjDRmBhrxNMWoWUy+RQeaQM68Vns/yU9h09YU6rhw3lcfM/nPjE40msnoozR9r4rCT1E4gOqKGFqz8HxM07DZ2iKJTj+sw3Lx3XAXWQ/0BIFyUTnIAr20ax1n6j4k6ZIc91ai3dvaNfHb7ngt/vscjcmhEVI4JUPlanGd4CRdCfIHiF/gBvqVHLucheM3pLAFh7mZKxElxc=" }
+      name { "Constant Chaum Pedersen Proof" }
+      pad { "yo4Xsd4W5ddd5KRT44/VMB1vFahfbhYVrA1gz6c9KWUohwR1ygMBwFHNgN+jfwqGKefSP1KzY9YTQTsARIRXdmfdxzMs7EIa5ylKmcBqP2BnC5l1WOJb+/NRXfltN1RNtx8gSICZ0rYIAcoqBVZJShTQRvZ2SUPDwhcw78wJJkFm3pMz9fH3/UCW+7c6iY1E6+cT/hi6m/3VaLGqVWMNTujrJo27FZp1cETNvCo9EKpJUYaWC5F3S4C1q9QFlwG5HOE2EsxrNyUiIxYhFi9YGt/mmXcASWjzck6lzQt92RO4U7I5t/B6jeq7Xx5hjbULbQtj/bdSAc4983TyCnLVjXE3EZwYoCLoNRg/biLBDIEOO6OPrfBmJoND5xdP50aoKmzjnj/Pg9Jns34cqc/S5DeVReiRMMuZ9R9eAiClu0IXKxORvWeD14RByoHUXI1KhGfV6DNyCmTXIVFbvJqVbFkqY60TVRqOwXRg9VozY7oG1f6KhGWqP4ZIXtYUlCO53hAIxh6DyMO1mVJ7/Ddqusc59O6916RJmdHUkKm0VZXEn3CBOTXkLRclb0LmdQ3559x1/HzY7Z6FsMsXQi7UMCaGW28TJFmj7x4XqXVUSyvxrrCeO8q3AuGkfgJjn+y02AjjIBFuEwSIDvxxqy+P5divFktS9p86qeVM8n5ax1Y=" }
+      response { "KhC1tJ3j86JL6uXICZTgBtyNP5U2GLrrKChKwbiszi0=" }
+      usage { "SelectionLimit" }
+    end
+
+    factory :selection_ballot do
+      transient do
+        contest_id { generate(:contest_id) }
+      end
+
+      ciphertext { build(:ciphertext) }
+      crypto_hash { "eZgMl6CRoLl1CJoMdOp/VUoN5qi0pVOegxFJS7QqauM=" }
+      description_hash { "c3MK/rIvA4poNcCvYKo+q4nww/SJ68nXaIoJjM3lQ9c=" }
+      is_placeholder_selection { false }
+      _object_id { "#{contest_id}-#{generate(:selection_id)}" }
+      proof { build(:selection_proof) }
+    end
+
+    factory :ciphertext do
+      pad { "samP9YzYLsSPBbhWr1jacr9FH9s4QrfLJcKSei48uFNf11STB+D18cEt5Hj523dkStJ61oGw9V6P6l82bpRk9KI5KhhAX9hS04lnSVx4zoY9CXzyROCExjnisc0sG10NL5GJZz0gNQXDO/KobRzG8OnucgZrX7Hk2otCF4ySeLEkgPSbA63V9f0460CCnbbZTk8CdhWOWzjN/Gk+0F1yLmdYZMs2SDVKCW0HISpzuBShEIJmQ1jRI9AwFoXuDKT+Mi5buanZuc5Zf5ApX8OY+Rh/x/MHQFNtDNa5ZGHEI1sWBBTPHXIBl8SCrRzSUVX6wCOMQyCtm/zLK3PMAizWE/eg8m87rp7tXNHy3kdAE5+joQ0egeITyPvmRpwXDc63rOBJ6p6AzMaz3Q+z0vntKwEXLuyLGzr0u+bR3lKf2j0LBAa2bWEUk2Junw+pHvQKvJiZ2NlppC3QJ3EFBdS/jblnIRlTDvu5CUTpwCwa6Q5hCp/S8RtWEef5eJ0dIi+Ws3NcAw799VrGVfn/ekhWNDBdZmOl9oJ9cX0e8NRyV9/pCgLFpQnZuSKN6NJFZfBXQetUAnYde8b6qIgrfGr3lfJSiEPZOTPxDvYvPkepCPCcYtlhJTH64zheO053az5G670Y9vveY5/tjHKGb47FYMPcN30/nuQvX/7WKF09zNM=" }
+      data { "JSiqgi+D4L2FbbaG41+m3ARFN+V1Kk8eepJsiPacMxJYWGbOQ/n7uFzx1XoZOGM/9B34GapQQGC92LQljSct0cGVP+sBFpiUJAc1GckKVZlYHCveTb2NEfnBVjC6qxupua0E+b1oVjzBLg2WDkizyTs2KPDAboImQjCUAETohabUme5hVqk9AtafW5WLIXWWN4To8v0bpL3RwlHaFd5//I9axsPMEQ5WLdP0akQXeB4ADaes43L25RGadZylmTpoPbQcWnXbu4oKlBq1U6jTzghyOV3nAyFAe4mRYcJav0Afy0ZQXc2yirsK7iuNfiYd2fE4GFOYKOkLy+67U4qNdT30H/yQUThzDEWyVeQMKCqaRYd5ynwOHBQ7PdVg0MGEbCAdDqAP+TigFDZgk6URhieDpAnWcMbePkA4qy9LS5bomQUjWF/+tYmb+0v+Dw8adpHsn5TgByVVHsAYLecaoifl3louSF6/8PKdFswNB5iemOGEcpOgTJMIr1QDr746LdA+V7W2Rt1+fVOKI9HWbx1+CvOrJA7C012dej27TDzBnHpfpuZTM2FyPSNOAxe3Hg1hK3luxl3k5MbizRjkqKam/TbfOK1CBNnEHRDzO289sjM+6G523KE+5IHvDiex/fD91om+Ez2kia4UX+DO9uTQ/u8hEWJNtE1ges6csIE=" }
+    end
+
+    factory :selection_proof do
+      challenge { "A81KTDONsn4ivK5iB1/u5kYS27SYBDAfYJUaU2xUYBo=" }
+      name { "Disjunctive Chaum Pedersen Proof" }
+      proof_one_challenge { "kEvG8XTr9rLVV1Xh9TaF0SvpUwR+yOe5zVAJXIYlAto=" }
+      proof_one_data { "gLhJIkPAz4Yy62GX2XLnWLYu9tlSAJzOBoU5RF1Qan+VsrBfpsxMeQHfmEnF36/yW37u1hYicRXvfHSsBxoVw3l68PDYDZ0nPlo+APTPmVvPOiF764HS3bVdGSkEwkxfKZSqAJ2yNUl8racMXzVa8m3Ny7fc4t/yXdsp0H+JY7VasJ2fD2NqlijFLSluzfPKyo8cuf3r7JVxL9jJxjTcNkUcp+LaJcUIKETydPA4WNrSlEPbj0Uu77Ia9ygChgK80AM1vkwrH2vXYKSsazQyGbx0tnRAKxtkclug0yKTtYe41EmXDK8f4i3krI7fX9Atv6xYMhEGo1xapYtKBZB3R6h2WPyVVOfgvAq2Sak1y6L3dM17/wAZGAeojGQAVJLR0jRbK0B5GtQkezSy51pNr8+DBrQf8EVWOBulo84r5mooCXqePF7o9RusWZiEReXX1y0P0ATzZYnaXjnUA3WClIxuiV5VbOHhtXxMYKs3P77oAvCX5MGTj3NfAmuHTpkCtRy9wrCsfJ9nsytzsqYgWJ0KcVNsm9mqD7ne0l3/QvZlIH7mvDOkuh+5aMkeUdKxsICW4vvHU+bcaaK0i91balMUuodcCKbZ3nbaaMxYOgYrOHY2ejYzW9TjpbqUZQ7bqBaWu3xzL/K/XpaZVMDdMpOgcJi+yg/0CkjzGKIwkJs=" }
+      proof_one_pad { "jYgXpGTOAnsrd444I0ZXX+hHLOHYKPv0wqv/1X5mCLZQ0uj5EfDNVO3XKHz8mipc06mNljdz/LsdCIAkRfZO2qFuftonZ510a/T52myy9QgZ11DwfjNujoL5Mz0CPRV1ez1gK+FVmdczWu7exZm7mlDzFCcdPFPyzc0/qkEU5kJEEny+PC9ewoGkj+wtm/aMxDx6KrrPAcF809Pp4vln0Hndh6pb3a6RJJJYf8Niapb94X6t59CL/0Wn4BzSPVHTZDRTK6GT0Rxzdd7mxVBVj+27hfYo7GSgY9dNA1DeCcwbJT63QJBb7boXzppKcOMBJpIWgpxpbX4RdU82tpdGVzTrFV8rWsXxrDpTQLuPo3A2Am8reGdoLu8vkkkzAY0vBcIOQExdXEs9W5sDxsLtovai9baqoNO9RSTLxiBSq80lg7FJEEWMJXnUhp8cHoNvKQNnczD/OqBtLBeec1+Amj8rk+VSu+YRIMgo368waU6c12xz7LtfoY0OSkhaVQKUnjWDwZvmLDJ5C8gFEuGpXRVKA7Yr49BClevPZcdTVuvq8qG7/LAKKwCdpLQVCYev3+OzypLQP3uWhhYchQfZQV59uv8AO9hbExCqj9qzc+oJSoPAZNmsmeLiUcrnCjGqF9yl1UJZlfSFf70K4guY8IdVHmUopPO2N7c7n5hOzGc=" }
+      proof_one_response { "eCGz+a1v+0jRHnSpXvpp6GggMKmniKxwSB4m9csBPNg=" }
+      proof_zero_challenge { "c4GDWr6hu8tNZViAEilpFRopiLAZO0hlk0UQ9uYvXIM=" }
+      proof_zero_data { "RP4KwGkNLqwUDiCa3ev+Vwx9u4EODFAxUE6OW2ANcHmLC7XeEO2uxI+qaLYdw7d2j2vA4CYzTzLXwFemEVCQXif/JxPzUwEXfIrFk0jc+EcY3ah3sM+gdT+3DeF+rerttNzLmlQpH5PyLb73qLsAk90xf0q36mzfSrpW00MN3/8y30dLKG3tAKEJtmE98lDdy6Vv7e7dk1bZmrgfggV5mzMV17MgHtHSusNdazMG5M7vx5SXRwycOGO02q88NrBwDsjF9B9/tucfO9C7mPHMbeDwglTRMm76SPDGym4ETcQiR88C4CUk6G6TzKe9Nf5YCIiR+glIbEtvy9NhazCEdSH4ETtVTF55AWPn306PxCX6jcgmzlHx9faWcx+DcBTXdZYJVClOH7gsg3apVEWrmdkz+nAnEONyqWNP9Mjw2d4gsSgOi/Q6aTbUvejVaVI9A9H/iPR5L/hwvVIgCJoWfET2kfxHdGanqtQBrJu5fL5BYMOTSOYEsB6P7jaE+Pevz5qfrJsyypVJ237XTDxii3qPrbAm0gUSbnu38zNPFAGN7M0WixL7qAWz+pKshClQ1wGikR3EJ+6leaau4Kg29+Ck3t4BywceGWXNucfg7SdkvupzAfTfAhz9DkTo7/rB8RzkqpT8wULwg1fQiubjVKZBPM6YHe9ABj1+1jvnuPc=" }
+      proof_zero_pad { "piFkW3bZFkBIFn45TTDK/GqjseMv+qoPeY4xyYqpKVtzSfqe/YaBjdyRxMGbJTWp3GoEN+vxbGK9tMwkKaiiwy8QRVJIL4wEeBEsdoI2RXf/hUkhFzRws3ITLbw+mkOuePWo0as0JVyfKNUdFPftNGlZwTrVKR3oP8BXqESUkHzrQlWujSKPZPII/5tLpid0fi/uj27pZqiwA8PCqPP9FnEXvFmF1dq7xG/OtbyTfRVOQctnbHJmqlZjKffo2PiYytP+7lncvoUdmA1SKaNEMz4Q51sKjuBR4lfOemZhj1pw75W4M6sQqA/abr6p4zwScrr1SjsCnVbQ0j35Or4ZNFZWxyRToU9Ri3pnYe0GR+KTbnHSRxUyfMd7DrypSZ/28w7n7cA/+HHpUUOrYigry5UDCHzKbPk9QrqrB2xUwtJJIx8FxAwKXafm7D0dLM172YXS92pCNotMMjzU2Of45f/aqrSgljVWNgFBpYGb62GuLXyyrxjQnvh9PDjgO0HxltFo19ZvrQJq55g8wEhaOfgwHNuoH/Di8TZ9GG8su+mKDio/qlKjG5NOBl12i/ks3zDSZW6PQ4cEGhjqZb/BxsB8u6lJf490irfuW7zbvKbzzUumhW+aIW9K+xdB2lZBdpCmc2zRywsng16IoQRED42dBeu5XSocu564Tw20Z5U=" }
+      proof_zero_response { "Jtb2ECiDdfcnA1WShU1BiDjd/WC+seU18AyBgrurgIM=" }
+      usage { "SelectionValue" }
     end
   end
 end

--- a/decidim-bulletin_board-app/spec/factories/models.rb
+++ b/decidim-bulletin_board-app/spec/factories/models.rb
@@ -62,11 +62,9 @@ FactoryBot.define do
 
   factory :pending_message, parent: :log_entry, class: :pending_message do
     status { :enqueued }
-    election { nil }
 
     trait :accepted do
       status { :accepted }
-      election
     end
 
     trait :rejected do

--- a/decidim-bulletin_board-app/spec/jobs/vote_job_spec.rb
+++ b/decidim-bulletin_board-app/spec/jobs/vote_job_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe VoteJob do
+  subject { described_class.perform_now(pending_message.id) }
+
+  let!(:pending_message) { create(:pending_message, election: election, message: message, client: authority, private_key: private_key) }
+  let(:election) { create(:election, status: :vote, authority: authority, authority_private_key: private_key) }
+  let(:authority) { create(:authority, private_key: private_key) }
+  let(:private_key) { generate(:private_key) }
+  let(:message) { build(:vote_message, election: election) }
+
+  it "processes the message" do
+    expect { subject }.to change { PendingMessage.last.status } .from("enqueued").to("accepted")
+  end
+
+  context "when the message is rejected" do
+    let(:message) { build(:vote_message, :invalid, election: election) }
+
+    it "rejects the message" do
+      expect { subject }.to change { PendingMessage.last.status } .from("enqueued").to("rejected")
+    end
+  end
+
+  context "when the message was already processed" do
+    before { described_class.perform_now(pending_message.id) }
+
+    it "doesn't change the message status" do
+      expect { subject }.not_to change { PendingMessage.last.status } .from("accepted")
+    end
+  end
+end

--- a/decidim-bulletin_board-app/spec/lib/message_identifier_spec.rb
+++ b/decidim-bulletin_board-app/spec/lib/message_identifier_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe MessageIdentifier do
 
   it { expect(subject).to be_from_authority }
   it { expect(subject).not_to be_from_trustee }
+  it { expect(subject).not_to be_from_voter }
   it { expect(subject.author_type).to eq(:authority) }
   it { expect(subject.author_id).to eq("decidim-barcelona") }
   it { expect(subject.authority_id).to eq("decidim-barcelona") }
@@ -23,6 +24,7 @@ RSpec.describe MessageIdentifier do
 
     it { expect(subject).not_to be_from_authority }
     it { expect(subject).to be_from_trustee }
+    it { expect(subject).not_to be_from_voter }
     it { expect(subject.author_type).to eq(:trustee) }
     it { expect(subject.author_id).to eq("trustee-1") }
     it { expect(subject.authority_id).to eq("decidim-barcelona") }
@@ -37,6 +39,7 @@ RSpec.describe MessageIdentifier do
 
     it { expect(subject).not_to be_from_authority }
     it { expect(subject).not_to be_from_trustee }
+    it { expect(subject).not_to be_from_voter }
     it { expect(subject.author_type).to eq(:bulletin_board) }
     it { expect(subject.author_id).to eq("metadecidim") }
     it { expect(subject.authority_id).to eq("decidim-barcelona") }
@@ -51,6 +54,7 @@ RSpec.describe MessageIdentifier do
 
     it { expect(subject).not_to be_from_authority }
     it { expect(subject).not_to be_from_trustee }
+    it { expect(subject).to be_from_voter }
     it { expect(subject.author_type).to eq(:voter) }
     it { expect(subject.author_id).to eq("50ad41624c25e493aa1dc7f4ab32bdc5a3b0b78ecc35b539") }
     it { expect(subject.authority_id).to eq("decidim-barcelona") }

--- a/decidim-bulletin_board-app/spec/models/pending_message_spec.rb
+++ b/decidim-bulletin_board-app/spec/models/pending_message_spec.rb
@@ -19,15 +19,6 @@ RSpec.describe PendingMessage do
     it { expect(subject).to be_processed }
     it { expect(subject).to be_accepted }
     it { expect(subject).not_to be_rejected }
-
-    context "when the election is not set" do
-      let(:pending_message) { build(:pending_message, :accepted, election: nil) }
-
-      it { expect(subject).not_to be_enqueued }
-      it { expect(subject).not_to be_processed }
-      it { expect(subject).to be_accepted }
-      it { expect(subject).not_to be_rejected }
-    end
   end
 
   context "when message has been rejected" do

--- a/decidim-bulletin_board-app/spec/mutations/process_key_ceremony_step_mutation_spec.rb
+++ b/decidim-bulletin_board-app/spec/mutations/process_key_ceremony_step_mutation_spec.rb
@@ -56,7 +56,9 @@ module Mutations
           client: {
             id: trustee.unique_id
           },
-          election: nil,
+          election: {
+            id: election.unique_id
+          },
           signedData: signed_data,
           status: "enqueued"
         },

--- a/decidim-bulletin_board-app/spec/mutations/vote_mutation_spec.rb
+++ b/decidim-bulletin_board-app/spec/mutations/vote_mutation_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Mutations
+  RSpec.describe VoteMutation, type: :request do
+    subject { post "/api", params: { query: query, variables: { messageId: message_id, signedData: signed_data } }, headers: headers }
+
+    let(:query) do
+      <<~GQL
+        mutation($messageId: String!, $signedData: String!) {
+          vote(messageId: $messageId, signedData: $signedData) {
+            pendingMessage {
+              id
+              client {
+                id
+              }
+              election {
+                id
+              }
+              signedData
+              status
+            }
+            error
+          }
+        }
+      GQL
+    end
+
+    let!(:election) { create(:election, authority: authority) }
+    let(:headers) { { "Authorization": authority.api_key } }
+    let(:authority) { create(:authority, private_key: private_key) }
+    let(:message_id) { payload["message_id"] }
+    let(:signed_data) { JWT.encode(payload.as_json, signature_key, "RS256") }
+    let(:private_key) { generate(:private_key) }
+    let(:signature_key) { private_key.keypair }
+    let(:payload) { build(:vote_message, election: election, authority: authority) }
+
+    it "adds the message to the pending messages table" do
+      expect { subject }.to change(PendingMessage, :count).by(1)
+    end
+
+    it "enqueues a key ceremony job to process the message", :jobs do
+      subject
+      expect(VoteJob).to have_been_enqueued
+    end
+
+    it "returns a pending message" do
+      subject
+      json = JSON.parse(response.body, symbolize_names: true)
+      data = json.dig(:data, :vote)
+
+      expect(data).to include(
+        pendingMessage: {
+          id: be_present,
+          client: {
+            id: authority.unique_id
+          },
+          election: {
+            id: election.unique_id
+          },
+          signedData: signed_data,
+          status: "enqueued"
+        },
+        error: nil
+      )
+    end
+
+    context "when the authority is not authorized" do
+      let(:headers) { {} }
+
+      it "doesn't create an election" do
+        expect { subject }.not_to change(Election, :count)
+      end
+
+      it "returns an error message" do
+        subject
+        json = JSON.parse(response.body, symbolize_names: true)
+        data = json.dig(:data, :vote)
+
+        expect(data).to include(
+          pendingMessage: nil,
+          error: "Authority not found"
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add the vote endpoint to the Bulletin Board, to receive and verify the ballots casted by the voters.

Related to decidim/decidim#6625

This PR also includes some improvements and refactors done before to simplify its implementation:
* Save the election reference with pending messages (#23)
* Improve the base classes for mutations 163ccd1 
* Improve the dummy voting scheme response generation ebe52d4

