### PR TITLE
Save election with pending messages

### DIFF
--- a/decidim-bulletin_board-app/app/commands/concerns/has_message_identifier.rb
+++ b/decidim-bulletin_board-app/app/commands/concerns/has_message_identifier.rb
@@ -12,5 +12,9 @@ module HasMessageIdentifier
     def message_identifier
       @message_identifier ||= MessageIdentifier.new(message_id)
     end
+
+    def election
+      @election ||= Election.find_by(unique_id: message_identifier.election_id)
+    end
   end
 end

--- a/decidim-bulletin_board-app/app/commands/concerns/log_entry_command.rb
+++ b/decidim-bulletin_board-app/app/commands/concerns/log_entry_command.rb
@@ -8,14 +8,14 @@ module LogEntryCommand
   included do
     include HasMessageIdentifier
 
-    attr_accessor :client, :signed_data, :log_entry, :error, :response_message
+    attr_accessor :client, :signed_data, :error, :response_message
     delegate :voting_scheme, to: :election
     delegate :decoded_data, to: :log_entry
 
     private
 
-    def build_log_entry
-      @log_entry = LogEntry.new(
+    def log_entry
+      @log_entry ||= LogEntry.new(
         message_id: message_id,
         signed_data: signed_data,
         client: client

--- a/decidim-bulletin_board-app/app/commands/create_election.rb
+++ b/decidim-bulletin_board-app/app/commands/create_election.rb
@@ -22,8 +22,6 @@ class CreateElection < Rectify::Command
   #
   # Returns nothing.
   def call
-    build_log_entry
-
     return broadcast(:invalid, error) unless
       valid_log_entry?("create_election") &&
       valid_step?(election.new_record?) &&

--- a/decidim-bulletin_board-app/app/commands/enqueue_message.rb
+++ b/decidim-bulletin_board-app/app/commands/enqueue_message.rb
@@ -38,12 +38,13 @@ class EnqueueMessage < Rectify::Command
   attr_reader :client, :signed_data, :job, :pending_message
 
   def valid?
-    client && message_id && signed_data && job
+    client && election && message_id && signed_data && job
   end
 
   def create_pending_message!
     @pending_message = PendingMessage.create!(
       client: client,
+      election: election,
       message_id: message_id,
       signed_data: signed_data,
       status: :enqueued

--- a/decidim-bulletin_board-app/app/commands/process_key_ceremony_step.rb
+++ b/decidim-bulletin_board-app/app/commands/process_key_ceremony_step.rb
@@ -58,8 +58,4 @@ class ProcessKeyCeremonyStep < Rectify::Command
       bulletin_board: true
     )
   end
-
-  def election
-    @election ||= Election.find_by(unique_id: message_identifier.election_id)
-  end
 end

--- a/decidim-bulletin_board-app/app/commands/process_key_ceremony_step.rb
+++ b/decidim-bulletin_board-app/app/commands/process_key_ceremony_step.rb
@@ -22,8 +22,6 @@ class ProcessKeyCeremonyStep < Rectify::Command
   #
   # Returns nothing.
   def call
-    build_log_entry
-
     return broadcast(:invalid, error) unless
       valid_log_entry?("key_ceremony")
 
@@ -38,7 +36,7 @@ class ProcessKeyCeremonyStep < Rectify::Command
       election.save!
     end
 
-    broadcast(:processed)
+    broadcast(:ok)
   end
 
   private

--- a/decidim-bulletin_board-app/app/commands/process_key_ceremony_step.rb
+++ b/decidim-bulletin_board-app/app/commands/process_key_ceremony_step.rb
@@ -17,7 +17,6 @@ class ProcessKeyCeremonyStep < Rectify::Command
 
   # Executes the command. Broadcasts these events:
   #
-  # - :election with the election model referred by the message
   # - :processed when everything is valid.
   # - :invalid if the received data wasn't valid.
   #
@@ -29,8 +28,6 @@ class ProcessKeyCeremonyStep < Rectify::Command
       valid_log_entry?("key_ceremony")
 
     election.with_lock do
-      broadcast(:election, election)
-
       return broadcast(:invalid, error) unless
         valid_step?(election.key_ceremony?) &&
         process_message

--- a/decidim-bulletin_board-app/app/jobs/process_key_ceremony_step_job.rb
+++ b/decidim-bulletin_board-app/app/jobs/process_key_ceremony_step_job.rb
@@ -10,11 +10,8 @@ class ProcessKeyCeremonyStepJob < ApplicationJob
       next unless pending_message.enqueued?
 
       ProcessKeyCeremonyStep.call(pending_message.client, pending_message.message_id, pending_message.signed_data) do
-        on(:election) { |election| pending_message.election = election }
         on(:processed) { |_result| pending_message.status = :accepted }
-        on(:invalid) do |_result, _message|
-          pending_message.status = :rejected
-        end
+        on(:invalid) { |_result, _message| pending_message.status = :rejected }
       end
 
       raise MessageNotProcessed unless pending_message.processed?

--- a/decidim-bulletin_board-app/app/jobs/process_key_ceremony_step_job.rb
+++ b/decidim-bulletin_board-app/app/jobs/process_key_ceremony_step_job.rb
@@ -10,7 +10,7 @@ class ProcessKeyCeremonyStepJob < ApplicationJob
       next unless pending_message.enqueued?
 
       ProcessKeyCeremonyStep.call(pending_message.client, pending_message.message_id, pending_message.signed_data) do
-        on(:processed) { |_result| pending_message.status = :accepted }
+        on(:ok) { |_result| pending_message.status = :accepted }
         on(:invalid) { |_result, _message| pending_message.status = :rejected }
       end
 

--- a/decidim-bulletin_board-app/app/models/pending_message.rb
+++ b/decidim-bulletin_board-app/app/models/pending_message.rb
@@ -7,6 +7,6 @@ class PendingMessage < ApplicationRecord
   enum status: [:enqueued, :rejected, :accepted].map { |status| [status, status.to_s] }.to_h
 
   def processed?
-    (accepted? && election) || rejected?
+    accepted? || rejected?
   end
 end

--- a/decidim-bulletin_board-app/app/models/pending_message.rb
+++ b/decidim-bulletin_board-app/app/models/pending_message.rb
@@ -2,7 +2,7 @@
 
 class PendingMessage < ApplicationRecord
   belongs_to :client
-  belongs_to :election, optional: true
+  belongs_to :election
 
   enum status: [:enqueued, :rejected, :accepted].map { |status| [status, status.to_s] }.to_h
 

--- a/decidim-bulletin_board-app/db/migrate/20201201141644_change_pending_messages_election_null.rb
+++ b/decidim-bulletin_board-app/db/migrate/20201201141644_change_pending_messages_election_null.rb
@@ -1,0 +1,5 @@
+class ChangePendingMessagesElectionNull < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null :pending_messages, :election_id, false
+  end
+end

--- a/decidim-bulletin_board-app/db/migrate/20201201141644_change_pending_messages_election_null.rb
+++ b/decidim-bulletin_board-app/db/migrate/20201201141644_change_pending_messages_election_null.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ChangePendingMessagesElectionNull < ActiveRecord::Migration[6.0]
   def change
     change_column_null :pending_messages, :election_id, false

--- a/decidim-bulletin_board-app/db/schema.rb
+++ b/decidim-bulletin_board-app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_17_095739) do
+ActiveRecord::Schema.define(version: 2020_12_01_141644) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -66,7 +66,7 @@ ActiveRecord::Schema.define(version: 2020_11_17_095739) do
   end
 
   create_table "pending_messages", force: :cascade do |t|
-    t.bigint "election_id"
+    t.bigint "election_id", null: false
     t.bigint "client_id", null: false
     t.text "signed_data", null: false
     t.string "status", default: "0", null: false

--- a/decidim-bulletin_board-app/spec/commands/enqueue_message_spec.rb
+++ b/decidim-bulletin_board-app/spec/commands/enqueue_message_spec.rb
@@ -24,6 +24,11 @@ RSpec.describe EnqueueMessage do
     expect(PendingMessage.last.client).to eq(client)
   end
 
+  it "stores the message election" do
+    subject
+    expect(PendingMessage.last.election).to eq(election)
+  end
+
   it "stores the message identifier" do
     subject
     expect(PendingMessage.last.message_id).to eq(message_id)

--- a/decidim-bulletin_board-app/spec/commands/process_key_ceremony_step_spec.rb
+++ b/decidim-bulletin_board-app/spec/commands/process_key_ceremony_step_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe ProcessKeyCeremonyStep do
   let(:message_type) { :key_ceremony_message }
   let(:message_params) { { election: election, trustee: trustee } }
 
-  it "broadcast processed" do
-    expect { subject }.to broadcast(:processed)
+  it "broadcast ok" do
+    expect { subject }.to broadcast(:ok)
   end
 
   it "creates the log entry for the message" do
@@ -41,8 +41,8 @@ RSpec.describe ProcessKeyCeremonyStep do
   context "when the voting scheme generates an answer" do
     let(:public_keys_already_sent) { trustees_plus_keys.map(&:first).excluding(trustee) }
 
-    it "broadcast processed" do
-      expect { subject }.to broadcast(:processed)
+    it "broadcast ok" do
+      expect { subject }.to broadcast(:ok)
     end
 
     it "creates the log entry for the message and another for the response" do

--- a/decidim-bulletin_board-app/spec/commands/process_key_ceremony_step_spec.rb
+++ b/decidim-bulletin_board-app/spec/commands/process_key_ceremony_step_spec.rb
@@ -22,10 +22,6 @@ RSpec.describe ProcessKeyCeremonyStep do
   let(:message_type) { :key_ceremony_message }
   let(:message_params) { { election: election, trustee: trustee } }
 
-  it "broadcast the election for the message" do
-    expect { subject }.to broadcast(:election, election)
-  end
-
   it "broadcast processed" do
     expect { subject }.to broadcast(:processed)
   end
@@ -44,10 +40,6 @@ RSpec.describe ProcessKeyCeremonyStep do
 
   context "when the voting scheme generates an answer" do
     let(:public_keys_already_sent) { trustees_plus_keys.map(&:first).excluding(trustee) }
-
-    it "broadcast the election for the message" do
-      expect { subject }.to broadcast(:election, election)
-    end
 
     it "broadcast processed" do
       expect { subject }.to broadcast(:processed)

--- a/decidim-bulletin_board-app/spec/factories/models.rb
+++ b/decidim-bulletin_board-app/spec/factories/models.rb
@@ -62,11 +62,9 @@ FactoryBot.define do
 
   factory :pending_message, parent: :log_entry, class: :pending_message do
     status { :enqueued }
-    election { nil }
 
     trait :accepted do
       status { :accepted }
-      election
     end
 
     trait :rejected do

--- a/decidim-bulletin_board-app/spec/models/pending_message_spec.rb
+++ b/decidim-bulletin_board-app/spec/models/pending_message_spec.rb
@@ -19,15 +19,6 @@ RSpec.describe PendingMessage do
     it { expect(subject).to be_processed }
     it { expect(subject).to be_accepted }
     it { expect(subject).not_to be_rejected }
-
-    context "when the election is not set" do
-      let(:pending_message) { build(:pending_message, :accepted, election: nil) }
-
-      it { expect(subject).not_to be_enqueued }
-      it { expect(subject).not_to be_processed }
-      it { expect(subject).to be_accepted }
-      it { expect(subject).not_to be_rejected }
-    end
   end
 
   context "when message has been rejected" do

--- a/decidim-bulletin_board-app/spec/mutations/process_key_ceremony_step_mutation_spec.rb
+++ b/decidim-bulletin_board-app/spec/mutations/process_key_ceremony_step_mutation_spec.rb
@@ -56,7 +56,9 @@ module Mutations
           client: {
             id: trustee.unique_id
           },
-          election: nil,
+          election: {
+            id: election.unique_id
+          },
           signedData: signed_data,
           status: "enqueued"
         },


### PR DESCRIPTION
After adding the identifiers to the messages we can get the election identifier without having to decode the signed message. So, its better to assign the election to the pending messages before enqueueing them to be processed. This PR implements this.