### PR TITLE
Add Voter to the Bulletin Board client

### DIFF
--- a/decidim-bulletin_board-js/src/voter/__mocks__/voter_wrapper_dummy.js
+++ b/decidim-bulletin_board-js/src/voter/__mocks__/voter_wrapper_dummy.js
@@ -1,0 +1,7 @@
+export class VoterWrapper {
+  constructor({ voterId }) {
+    this.voterId = voterId;
+  }
+
+  encrypt() {}
+}

--- a/decidim-bulletin_board-js/src/voter/voter.js
+++ b/decidim-bulletin_board-js/src/voter/voter.js
@@ -1,0 +1,29 @@
+import { VoterWrapper } from "./voter_wrapper_dummy";
+
+/**
+ * This is a facade class that will use the correspondig `VoterWrapper` to encrypt
+ * the vote.
+ */
+export class Voter {
+  /**
+   * Initializes the class with the given params.
+   *
+   * @constructor
+   * @param {Object} params - An object that contains the initialization params.
+   *  - {String} id - The voter identifier.
+   */
+  constructor({ id }) {
+    this.id = id;
+    this.wrapper = new VoterWrapper({ voterId: id });
+  }
+
+  /**
+   * Encrypts the data using the wrapper.
+   *
+   * @param {Object} data - The data to be.
+   * @returns {Object} - The data encrypted.
+   */
+  async encrypt(data) {
+    return this.wrapper.encrypt(data);
+  }
+}

--- a/decidim-bulletin_board-js/src/voter/voter.test.js
+++ b/decidim-bulletin_board-js/src/voter/voter.test.js
@@ -1,0 +1,38 @@
+import { Voter } from "./voter";
+
+jest.mock("./voter_wrapper_dummy");
+
+describe("Voter", () => {
+  const defaultParams = {
+    id: "voter-1",
+  };
+
+  const buildVoter = (params = defaultParams) => {
+    return new Voter(params);
+  };
+
+  let voter;
+
+  beforeEach(() => {
+    voter = buildVoter();
+  });
+
+  it("initialise the voter wrapper with the given params", () => {
+    expect(voter.id).toEqual(defaultParams.id);
+    expect(voter.wrapper.voterId).toEqual(defaultParams.id);
+  });
+
+  describe("encrypt", () => {
+    it("calls the wrapper's encrypt method with the given data", async () => {
+      spyOn(voter.wrapper, "encrypt");
+      await voter.encrypt({
+        question1: ["answer-1-option-a"],
+        question2: ["answer-2-option-a", "answer-2-option-b"],
+      });
+      expect(voter.wrapper.encrypt).toHaveBeenCalledWith({
+        question1: ["answer-1-option-a"],
+        question2: ["answer-2-option-a", "answer-2-option-b"],
+      });
+    });
+  });
+});

--- a/decidim-bulletin_board-js/src/voter/voter_wrapper_dummy.js
+++ b/decidim-bulletin_board-js/src/voter/voter_wrapper_dummy.js
@@ -1,0 +1,13 @@
+/**
+ * This is just a dummy implementation of a possible `VoterWrapper`.
+ * It is based on the dummy voting schema that we are using in the Bulletin Board.
+ */
+export class VoterWrapper {
+  constructor({ voterId }) {
+    this.voterId = voterId;
+  }
+
+  encrypt(data) {
+    return data;
+  }
+}

--- a/decidim-bulletin_board-ruby/Gemfile.lock
+++ b/decidim-bulletin_board-ruby/Gemfile.lock
@@ -2,14 +2,18 @@ PATH
   remote: .
   specs:
     decidim-bulletin_board (0.1.0)
+      activemodel (~> 5.0, >= 5.0.0.1)
       activesupport (~> 5.0, >= 5.0.0.1)
       byebug (~> 11.0)
       graphlient (~> 0.4.0)
       jwt
+      wisper (~> 2.0.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    activemodel (5.2.4.4)
+      activesupport (= 5.2.4.4)
     activesupport (5.2.4.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
@@ -91,6 +95,8 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
+    wisper (2.0.1)
+    wisper-rspec (1.1.0)
 
 PLATFORMS
   ruby
@@ -103,6 +109,7 @@ DEPENDENCIES
   rubocop-faker
   rubocop-rspec (~> 1.21)
   webmock (~> 3.6)
+  wisper-rspec (~> 1.1.0)
 
 BUNDLED WITH
    2.1.4

--- a/decidim-bulletin_board-ruby/decidim-bulletin_board.gemspec
+++ b/decidim-bulletin_board-ruby/decidim-bulletin_board.gemspec
@@ -23,12 +23,15 @@ Gem::Specification.new do |s|
   s.executables = s.files.grep(%r{^exe/}) { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
+  s.add_dependency "activemodel", "~> 5.0", ">= 5.0.0.1"
   s.add_dependency "activesupport", "~> 5.0", ">= 5.0.0.1"
   s.add_dependency "byebug", "~> 11.0"
   s.add_dependency "graphlient", "~> 0.4.0"
   s.add_dependency "jwt"
+  s.add_dependency "wisper", "~> 2.0.0"
 
   s.add_development_dependency "rake", "~> 13.0"
   s.add_development_dependency "rspec", "~> 3.7"
   s.add_development_dependency "webmock", "~> 3.6"
+  s.add_development_dependency "wisper-rspec", "~> 1.1.0"
 end

--- a/decidim-bulletin_board-ruby/lib/decidim/bulletin_board.rb
+++ b/decidim-bulletin_board-ruby/lib/decidim/bulletin_board.rb
@@ -2,10 +2,13 @@
 
 require "decidim/bulletin_board/version"
 require "graphlient"
+require "wisper"
+require "active_model"
 require "decidim/bulletin_board/jwk_utils"
 require "decidim/bulletin_board/client"
 require "decidim/bulletin_board/graphql/client"
 require "decidim/bulletin_board/create_election"
+require "decidim/bulletin_board/voter"
 require "active_support/configurable"
 require "jwt"
 

--- a/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/client.rb
+++ b/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/client.rb
@@ -34,9 +34,21 @@ module Decidim
         private_key && server && api_key
       end
 
+      def sign_data(data)
+        JWT.encode(data, identification_private_key.keypair, "RS256")
+      end
+
       def setup_election(election_data)
         message_id = "#{election_data[:election_id]}.create_election+a.#{authority_slug}"
         Decidim::BulletinBoard::CreateElection.call(election_data, message_id)
+      end
+
+      def cast_vote(election_data, voter_data, encrypted_vote)
+        form = Decidim::BulletinBoard::Voter::VoteForm.new(self, election_data, voter_data, encrypted_vote)
+        cast_vote = Decidim::BulletinBoard::Voter::CastVote.new(form)
+        cast_vote.on(:ok) { |pending_message| return pending_message }
+        cast_vote.on(:error) { |error_message| raise StandardError, error_message }
+        cast_vote.call
       end
 
       private

--- a/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/version.rb
+++ b/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/version.rb
@@ -2,6 +2,6 @@
 
 module Decidim
   module BulletinBoard
-    VERSION = "0.1.0"
+    VERSION = "0.2.0"
   end
 end

--- a/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/voter.rb
+++ b/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/voter.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+require "decidim/bulletin_board/voter/cast_vote"
+require "decidim/bulletin_board/voter/vote_form"

--- a/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/voter/cast_vote.rb
+++ b/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/voter/cast_vote.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Decidim
+  module BulletinBoard
+    module Voter
+      # This command uses the GraphQL client to cast the vote.
+      class CastVote
+        include Wisper::Publisher
+        # Public: Initializes the command.
+        #
+        # form - A form object with the params.
+        def initialize(form)
+          @form = form
+        end
+
+        # Executes the command. Broadcasts these events:
+        #
+        # - :ok when everything is valid and the mutation operation is successful.
+        # - :error if the form wasn't valid or the mutation operation was not successful.
+        #
+        # Returns nothing.
+        def call
+          return broadcast(:error, form.errors.full_messages.join(". ")) unless form.valid?
+
+          args = {
+            message_id: form.message_id,
+            signed_data: form.signed_data
+          }
+
+          begin
+            response = client.query do
+              mutation do
+                vote(messageId: args[:message_id], signedData: args[:signed_data]) do
+                  pendingMessage do
+                    status
+                  end
+                  error
+                end
+              end
+            end
+
+            return broadcast(:error, response.data.vote.error) if response.data.vote.error.present?
+
+            broadcast(:ok, response.data.vote.pending_message)
+          rescue Graphlient::Errors::FaradayServerError
+            broadcast(:error, "something went wrong")
+          end
+        end
+
+        private
+
+        attr_reader :form
+
+        def client
+          @client ||= BulletinBoard::Graphql::Client.client
+        end
+      end
+    end
+  end
+end

--- a/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/voter/vote_form.rb
+++ b/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/voter/vote_form.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module Decidim
+  module BulletinBoard
+    module Voter
+      # A form object to handle some data transformation and validation to cast a vote.
+      class VoteForm
+        include ActiveModel::Validations
+
+        validates :election_data, :voter_data, :encrypted_vote, presence: true
+        validate :election_id_present
+        validate :voter_id_present
+
+        # Public: initialize the form
+        #
+        # bulletin_board_data - An instance of the bulletin board client
+        # election_data - A Hash including the necessary data from the election.
+        # voter_data - A Hash including the necessary data from the voter.
+        # encrypted_vote - A Hash including the encrypted vote to cast
+        def initialize(bulletin_board_client, election_data, voter_data, encrypted_vote)
+          @bulletin_board_client = bulletin_board_client
+          @election_data = election_data
+          @voter_data = voter_data
+          @encrypted_vote = encrypted_vote
+        end
+
+        # Public: returns a message identifier for the cast vote operation.
+        def message_id
+          @message_id ||= "#{election_id}.vote.cast+v.#{voter_id}"
+        end
+
+        # Public: uses the bulletin board client to sign the encrypted vote merged with the `message_id`.
+        def signed_data
+          @signed_data ||= bulletin_board_client.sign_data(encrypted_vote.merge(message_id: message_id))
+        end
+
+        private
+
+        attr_reader :bulletin_board_client, :election_data, :voter_data, :encrypted_vote
+
+        def election_id_present
+          errors.add(:election_data, "doesn't include the election id") unless election_id.present?
+        end
+
+        def election_id
+          return if election_data.blank?
+
+          election_data[:election_id]
+        end
+
+        def voter_id_present
+          errors.add(:voter_data, "doesn't include the voter id") unless voter_id.present?
+        end
+
+        def voter_id
+          return if voter_data.blank?
+
+          voter_data[:voter_id]
+        end
+      end
+    end
+  end
+end

--- a/decidim-bulletin_board-ruby/spec/decidim/bulletin_board/client_spec.rb
+++ b/decidim-bulletin_board-ruby/spec/decidim/bulletin_board/client_spec.rb
@@ -3,6 +3,7 @@
 require "spec_helper"
 require "decidim/bulletin_board/client"
 require "decidim/bulletin_board/jwk_utils"
+require "wisper/rspec/stub_wisper_publisher"
 
 module Decidim
   module BulletinBoard
@@ -68,6 +69,39 @@ module Decidim
         let(:api_key) { "" }
 
         it { is_expected.not_to be_configured }
+      end
+
+      describe "cast_vote" do
+        let(:election_data) do
+          { election_id: "test.1" }
+        end
+        let(:voter_data) do
+          { voter_id: "voter.1" }
+        end
+        let(:encrypted_vote) do
+          { question_1: "aNsWeR 1" }
+        end
+
+        context "when everything went ok" do
+          before do
+            stub_wisper_publisher("Decidim::BulletinBoard::Voter::CastVote", :call, :ok, double(status: "enqueued"))
+          end
+
+          it "calls the CastVote command and return the result" do
+            pending_message = subject.cast_vote(election_data, voter_data, encrypted_vote)
+            expect(pending_message.status).to eq("enqueued")
+          end
+        end
+
+        context "when something went wrong" do
+          before do
+            stub_wisper_publisher("Decidim::BulletinBoard::Voter::CastVote", :call, :error, "something went wrong")
+          end
+
+          it "calls the CastVote command and throws an error" do
+            expect { subject.cast_vote(election_data, voter_data, encrypted_vote) }.to raise_error("something went wrong")
+          end
+        end
       end
     end
   end

--- a/decidim-bulletin_board-ruby/spec/decidim/bulletin_board/voter/cast_vote_spec.rb
+++ b/decidim-bulletin_board-ruby/spec/decidim/bulletin_board/voter/cast_vote_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module BulletinBoard
+    module Voter
+      describe CastVote do
+        subject { described_class.new(form) }
+
+        let(:form) { double(valid?: valid, errors: errors, message_id: message_id, signed_data: signed_data) }
+        let(:valid) { true }
+        let(:errors) { nil }
+        let(:message_id) { "test.1.vote.cast+v.voter.1" }
+        let(:signed_data) { "123456789" }
+
+        let(:vote_mutation_response) do
+          {
+            "data" => {
+              "vote" => {
+                "pendingMessage" => {
+                  "status" => "enqueued"
+                }
+              }
+            }
+          }.to_json
+        end
+        let(:server_url) { "https://example.org/api" }
+
+        before do
+          allow(Decidim::BulletinBoard::Graphql::Client).to receive(:client).and_return(
+            Graphlient::Client.new(server_url, schema_path: "spec/fixtures/bb_schema.json")
+          )
+          stub_request(:post, server_url).to_return(status: 200, body: vote_mutation_response)
+        end
+
+        context "when everything is ok" do
+          it "broadcasts ok with the result of the graphql mutation" do
+            expect { subject.call }.to broadcast(:ok)
+          end
+
+          it "uses the graphql client to perform a Vote mutation and return its result" do
+            subject.on(:ok) do |pending_message|
+              expect(pending_message.status).to eq("enqueued")
+            end
+            subject.call
+          end
+        end
+
+        context "when the form is not valid" do
+          let(:valid) { false }
+          let(:errors) { double(full_messages: ["something went wrong"]) }
+
+          it "broadcasts error with the form error messages" do
+            expect { subject.call }.to broadcast(:error, "something went wrong")
+          end
+        end
+
+        context "when the graphql operation returns a expected error" do
+          let(:vote_mutation_response) do
+            {
+              "data" => {
+                "vote" => {
+                  "error" => "vote cannot be emitted"
+                }
+              }
+            }.to_json
+          end
+
+          it "broadcasts error with the expected error message" do
+            expect { subject.call }.to broadcast(:error, "vote cannot be emitted")
+          end
+        end
+
+        context "when the graphql operation returns an unexpected error" do
+          before do
+            stub_request(:post, server_url).to_return(status: 500)
+          end
+
+          it "broadcasts error with the unexpected error" do
+            expect { subject.call }.to broadcast(:error, "something went wrong")
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-bulletin_board-ruby/spec/decidim/bulletin_board/voter/vote_form_spec.rb
+++ b/decidim-bulletin_board-ruby/spec/decidim/bulletin_board/voter/vote_form_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module BulletinBoard
+    module Voter
+      describe VoteForm do
+        subject { described_class.new(bulletin_board_client, election_data, voter_data, encrypted_vote) }
+
+        let(:bulletin_board_client) { double(sign_data: "123456789") }
+        let(:election_data) do
+          { election_id: "test.1" }
+        end
+        let(:voter_data) do
+          { voter_id: "voter.1" }
+        end
+        let(:encrypted_vote) do
+          { question_1: "aNsWeR 1" }
+        end
+
+        describe("when the election data doesn't include the election_id") do
+          let(:election_data) do
+            { foo: "bar" }
+          end
+
+          it { is_expected.not_to be_valid }
+        end
+
+        describe("when the voter data doesn't include the voter_id") do
+          let(:voter_data) do
+            { foo: "bar" }
+          end
+
+          it { is_expected.not_to be_valid }
+        end
+
+        describe("when the encrypted vote is not present") do
+          let(:encrypted_vote) { nil }
+
+          it { is_expected.not_to be_valid }
+        end
+
+        describe "message_id" do
+          it "returns a string including the necessary info to cast a vote" do
+            expect(subject.message_id).to eq("test.1.vote.cast+v.voter.1")
+          end
+        end
+
+        describe "signed_data" do
+          it "returns a string with the encrypted vote signed by the authority" do
+            expect(subject.signed_data).to eq("123456789")
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-bulletin_board-ruby/spec/spec_helper.rb
+++ b/decidim-bulletin_board-ruby/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require "bundler/setup"
 require "decidim/bulletin_board"
 require "byebug"
 require "webmock/rspec"
+require "wisper/rspec/matchers"
 
 RSpec.configure do |config|
   config.color = true
@@ -12,4 +13,5 @@ RSpec.configure do |config|
   config.raise_errors_for_deprecations!
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
+  config.include(Wisper::RSpec::BroadcastMatcher)
 end


### PR DESCRIPTION
In this PR I am gonna enhance the `decidim-bulletin_board` npm package and the `decidim-bulletin_board` gem to include the business logic necessary to vote.
I decided to split the work in different PRs and merging everything in this one.

- Add the `Voter` and `VoterWrapper` (dummy) classes https://github.com/decidim/decidim-bulletin-board/commit/ae50a9745c4734a3cfde544d6b271db89e6985ec
- Cast vote from the Ruby client using the `cast_vote` method. https://github.com/decidim/decidim-bulletin-board/pull/30
- Bump decidim-bulletin_board v0.2.0 https://github.com/decidim/decidim-bulletin-board/pull/25/commits/43f249d27cc4a5fce06ebdee1fb0617a6a955ca2