### PR TITLE
chore: deprecate logType for log entries

### DIFF
--- a/decidim-bulletin_board-app/app/graphql/types/log_entry_type.rb
+++ b/decidim-bulletin_board-app/app/graphql/types/log_entry_type.rb
@@ -7,6 +7,6 @@ module Types
     field :client, Types::ClientType, null: false
     field :signed_data, String, null: false
     field :chained_hash, String, null: false
-    field :log_type, String, null: false
+    field :message_id, String, null: false
   end
 end

--- a/decidim-bulletin_board-app/spec/queries/get_election_log_entries_spec.rb
+++ b/decidim-bulletin_board-app/spec/queries/get_election_log_entries_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "GetElectionLogEntries" do
       query GetElectionLogEntries {
         election(uniqueId: "#{election_unique_id}") {
           logEntries {
-            logType
+            messageId
             signedData
           }
         }

--- a/decidim-bulletin_board-js/src/client/graphql-client.test.js
+++ b/decidim-bulletin_board-js/src/client/graphql-client.test.js
@@ -21,8 +21,8 @@ describe("GraphQLClient", () => {
   describe("getElectionLogEntries", () => {
     it("returns all the log entries given a election id", async () => {
       const logEntriesResult = [
-        { logType: "dummy.1", signedData: "1234" },
-        { logType: "dummy.2", signedData: "5678" },
+        { messageId: "dummy.1", signedData: "1234" },
+        { messageId: "dummy.2", signedData: "5678" },
       ];
 
       fetch.mockResponseOnce(

--- a/decidim-bulletin_board-js/src/client/operations/get_election_log_entries.gql
+++ b/decidim-bulletin_board-js/src/client/operations/get_election_log_entries.gql
@@ -1,7 +1,7 @@
 query GetElectionLogEntries($electionUniqueId: String!) {
   election(uniqueId: $electionUniqueId) {
     logEntries {
-      logType
+      messageId
       signedData
     }
   }

--- a/decidim-bulletin_board-js/src/client/operations/subscribe_to_election_log.gql
+++ b/decidim-bulletin_board-js/src/client/operations/subscribe_to_election_log.gql
@@ -1,7 +1,7 @@
 subscription SubscribeToElectionLog($electionUniqueId: String!) {
   electionLogEntryAdded(electionUniqueId: $electionUniqueId) {
     logEntry {
-      logType
+      messageId
       signedData
     }
   }

--- a/decidim-bulletin_board-js/src/key-ceremony/key-ceremony.test.js
+++ b/decidim-bulletin_board-js/src/key-ceremony/key-ceremony.test.js
@@ -76,8 +76,8 @@ describe("KeyCeremony", () => {
         expect.any(Function)
       );
 
-      electionLogEntriesUpdates.next({ logType: "foo", signedData: "1234" });
-      electionLogEntriesUpdates.next({ logType: "foo", signedData: "5678" });
+      electionLogEntriesUpdates.next({ messageId: "foo", signedData: "1234" });
+      electionLogEntriesUpdates.next({ messageId: "foo", signedData: "5678" });
       expect(keyCeremony.electionLogEntries.length).toEqual(2);
     });
   });
@@ -89,7 +89,7 @@ describe("KeyCeremony", () => {
 
     it("always processes the first log entry", async () => {
       electionLogEntriesUpdates.next({
-        logType: "dummy.done",
+        messageId: "dummy.done",
         signedData: "1234",
       });
       const result = await keyCeremony.run();
@@ -103,11 +103,11 @@ describe("KeyCeremony", () => {
 
     it("processes all messages until done", async () => {
       electionLogEntriesUpdates.next({
-        logType: "dummy.step",
+        messageId: "dummy.step",
         signedData: "1234",
       });
       electionLogEntriesUpdates.next({
-        logType: "dummy.done",
+        messageId: "dummy.done",
         signedData: "5678",
       });
       const result = await keyCeremony.run();
@@ -124,11 +124,11 @@ describe("KeyCeremony", () => {
 
     it("skips the processed log entries that doesn't output a result", async () => {
       electionLogEntriesUpdates.next({
-        logType: "dummy.nothing",
+        messageId: "dummy.nothing",
         signedData: "1234",
       });
       electionLogEntriesUpdates.next({
-        logType: "dummy.done",
+        messageId: "dummy.done",
         signedData: "5678",
       });
       const result = await keyCeremony.run();
@@ -146,11 +146,11 @@ describe("KeyCeremony", () => {
       let events = [];
 
       electionLogEntriesUpdates.next({
-        logType: "dummy.nothing",
+        messageId: "dummy.nothing",
         signedData: "1234",
       });
       electionLogEntriesUpdates.next({
-        logType: "dummy.done",
+        messageId: "dummy.done",
         signedData: "5678",
       });
 
@@ -163,14 +163,14 @@ describe("KeyCeremony", () => {
       expect(events[0]).toEqual({
         type: MESSAGE_RECEIVED,
         message: {
-          logType: "dummy.nothing",
+          messageId: "dummy.nothing",
           signedData: "1234",
         },
       });
       expect(events[1]).toEqual({
         type: MESSAGE_PROCESSED,
         message: {
-          logType: "dummy.nothing",
+          messageId: "dummy.nothing",
           signedData: "1234",
         },
         result: null,
@@ -178,14 +178,14 @@ describe("KeyCeremony", () => {
       expect(events[2]).toEqual({
         type: MESSAGE_RECEIVED,
         message: {
-          logType: "dummy.done",
+          messageId: "dummy.done",
           signedData: "5678",
         },
       });
       expect(events[3]).toEqual({
         type: MESSAGE_PROCESSED,
         message: {
-          logType: "dummy.done",
+          messageId: "dummy.done",
           signedData: "5678",
         },
         result: { done: true, message: { signedData: "5678" } },

--- a/decidim-bulletin_board-js/src/trustee/__mocks__/trustee.js
+++ b/decidim-bulletin_board-js/src/trustee/__mocks__/trustee.js
@@ -1,6 +1,6 @@
 export class Trustee {
-  processLogEntry({ logType, signedData }) {
-    switch (logType) {
+  processLogEntry({ messageId, signedData }) {
+    switch (messageId) {
       case "dummy.nothing": {
         return null;
       }

--- a/decidim-bulletin_board-js/src/trustee/trustee.js
+++ b/decidim-bulletin_board-js/src/trustee/trustee.js
@@ -28,9 +28,9 @@ export class Trustee {
    * @param {Object} logEntry - The log entry to be processed.
    * @returns {Promise<Object>} - The result of the processing if any.
    */
-  async processLogEntry({ logType, signedData }) {
+  async processLogEntry({ messageId, signedData }) {
     const payload = await this.parser.parse(signedData);
-    return this.wrapper.processMessage(logType, payload);
+    return this.wrapper.processMessage(messageId, payload);
   }
 
   /**

--- a/decidim-bulletin_board-js/src/trustee/trustee.test.js
+++ b/decidim-bulletin_board-js/src/trustee/trustee.test.js
@@ -32,7 +32,7 @@ describe("Trustee", () => {
     it("calls the wrapper's process message method with the parsed data", async () => {
       spyOn(trustee.wrapper, "processMessage");
       await trustee.processLogEntry({
-        logType: "dummy",
+        messageId: "dummy",
         signedData: "1234",
       });
       expect(trustee.wrapper.processMessage).toHaveBeenCalledWith(

--- a/decidim-bulletin_board-js/src/trustee/trustee_wrapper_dummy.js
+++ b/decidim-bulletin_board-js/src/trustee/trustee_wrapper_dummy.js
@@ -15,10 +15,10 @@ export class TrusteeWrapper {
     this.processedMessages = [];
   }
 
-  processMessage(logType, message) {
+  processMessage(messageId, message) {
     switch (this.status) {
       case CREATE_ELECTION: {
-        if (logType === CREATE_ELECTION) {
+        if (messageId === CREATE_ELECTION) {
           this.status = KEY_CEREMONY;
           this.electionId = message.election_id;
           this.processedMessages = [];
@@ -37,7 +37,7 @@ export class TrusteeWrapper {
         break;
       }
       case KEY_CEREMONY: {
-        if (logType === KEY_CEREMONY && message.owner_id !== this.trusteeId) {
+        if (messageId === KEY_CEREMONY && message.owner_id !== this.trusteeId) {
           this.processedMessages = [...this.processedMessages, message];
           if (
             this.processedMessages.length ===
@@ -53,7 +53,7 @@ export class TrusteeWrapper {
         break;
       }
       case JOINT_ELECTION_KEY: {
-        if (logType === JOINT_ELECTION_KEY) {
+        if (messageId === JOINT_ELECTION_KEY) {
           return {
             done: true,
             message,

--- a/decidim-bulletin_board-ruby/spec/fixtures/bb_schema.json
+++ b/decidim-bulletin_board-ruby/spec/fixtures/bb_schema.json
@@ -390,7 +390,7 @@
               "deprecationReason": null
             },
             {
-              "name": "logType",
+              "name": "messageId",
               "description": null,
               "args": [
 


### PR DESCRIPTION
This deprecated the `logType` field since it has been replaced by the `messageId`.