### PR TITLE
Validate client type and message author in commands

### DIFF
--- a/decidim-bulletin_board-app/app/commands/concerns/log_entry_command.rb
+++ b/decidim-bulletin_board-app/app/commands/concerns/log_entry_command.rb
@@ -55,6 +55,12 @@ module LogEntryCommand
       end
     end
 
+    def valid_author?(valid)
+      run_validations do
+        "Invalid message author" unless valid
+      end
+    end
+
     def process_message
       @response_message = voting_scheme.process_message(message_identifier, log_entry.decoded_data)
       election.voting_scheme_state = voting_scheme.backup

--- a/decidim-bulletin_board-app/app/commands/concerns/log_entry_command.rb
+++ b/decidim-bulletin_board-app/app/commands/concerns/log_entry_command.rb
@@ -49,6 +49,12 @@ module LogEntryCommand
       end
     end
 
+    def valid_client?(valid)
+      run_validations do
+        "Invalid client" unless valid
+      end
+    end
+
     def process_message
       @response_message = voting_scheme.process_message(message_identifier, log_entry.decoded_data)
       election.voting_scheme_state = voting_scheme.backup

--- a/decidim-bulletin_board-app/app/commands/create_election.rb
+++ b/decidim-bulletin_board-app/app/commands/create_election.rb
@@ -24,6 +24,7 @@ class CreateElection < Rectify::Command
   def call
     return broadcast(:invalid, error) unless
       valid_log_entry?("create_election") &&
+      valid_client?(client.authority?) &&
       valid_step?(election.new_record?) &&
       valid_election? &&
       valid_questions? &&

--- a/decidim-bulletin_board-app/app/commands/create_election.rb
+++ b/decidim-bulletin_board-app/app/commands/create_election.rb
@@ -25,6 +25,7 @@ class CreateElection < Rectify::Command
     return broadcast(:invalid, error) unless
       valid_log_entry?("create_election") &&
       valid_client?(client.authority?) &&
+      valid_author?(message_identifier.from_authority?) &&
       valid_step?(election.new_record?) &&
       valid_election? &&
       valid_questions? &&

--- a/decidim-bulletin_board-app/app/commands/process_key_ceremony_step.rb
+++ b/decidim-bulletin_board-app/app/commands/process_key_ceremony_step.rb
@@ -27,6 +27,7 @@ class ProcessKeyCeremonyStep < Rectify::Command
 
     election.with_lock do
       return broadcast(:invalid, error) unless
+        valid_client?(client.trustee?) &&
         valid_step?(election.key_ceremony?) &&
         process_message
 

--- a/decidim-bulletin_board-app/app/commands/process_key_ceremony_step.rb
+++ b/decidim-bulletin_board-app/app/commands/process_key_ceremony_step.rb
@@ -28,6 +28,7 @@ class ProcessKeyCeremonyStep < Rectify::Command
     election.with_lock do
       return broadcast(:invalid, error) unless
         valid_client?(client.trustee?) &&
+        valid_author?(message_identifier.from_trustee?) &&
         valid_step?(election.key_ceremony?) &&
         process_message
 

--- a/decidim-bulletin_board-app/app/commands/vote.rb
+++ b/decidim-bulletin_board-app/app/commands/vote.rb
@@ -26,6 +26,7 @@ class Vote < Rectify::Command
       valid_log_entry?("vote")
 
     return broadcast(:invalid, error) unless
+      valid_client?(client.authority?) &&
       valid_step?(election.vote?) &&
       process_message
 

--- a/decidim-bulletin_board-app/app/commands/vote.rb
+++ b/decidim-bulletin_board-app/app/commands/vote.rb
@@ -27,6 +27,7 @@ class Vote < Rectify::Command
 
     return broadcast(:invalid, error) unless
       valid_client?(client.authority?) &&
+      valid_author?(message_identifier.from_voter?) &&
       valid_step?(election.vote?) &&
       process_message
 

--- a/decidim-bulletin_board-app/app/models/authority.rb
+++ b/decidim-bulletin_board-app/app/models/authority.rb
@@ -2,4 +2,8 @@
 
 class Authority < Client
   has_many :elections
+
+  def authority?
+    true
+  end
 end

--- a/decidim-bulletin_board-app/app/models/bulletin_board.rb
+++ b/decidim-bulletin_board-app/app/models/bulletin_board.rb
@@ -66,6 +66,10 @@ class BulletinBoard
       "Bulletin Board"
     end
 
+    def bulletin_board?
+      true
+    end
+
     def unique_id
       name.parameterize
     end

--- a/decidim-bulletin_board-app/app/models/client.rb
+++ b/decidim-bulletin_board-app/app/models/client.rb
@@ -11,4 +11,16 @@ class Client < ApplicationRecord
   def public_key_rsa
     @public_key_rsa ||= JWT::JWK::RSA.import(public_key.symbolize_keys).public_key
   end
+
+  def authority?
+    false
+  end
+
+  def bulletin_board?
+    false
+  end
+
+  def trustee?
+    false
+  end
 end

--- a/decidim-bulletin_board-app/app/models/trustee.rb
+++ b/decidim-bulletin_board-app/app/models/trustee.rb
@@ -3,4 +3,8 @@
 class Trustee < Client
   has_many :election_trustees
   has_many :elections, through: :election_trustees
+
+  def trustee?
+    true
+  end
 end

--- a/decidim-bulletin_board-app/spec/commands/create_election_spec.rb
+++ b/decidim-bulletin_board-app/spec/commands/create_election_spec.rb
@@ -104,4 +104,13 @@ RSpec.describe CreateElection do
       expect { subject }.to broadcast(:invalid)
     end
   end
+
+  context "when the message author is not the authority" do
+    let(:message_id) { "#{authority.unique_id}.26.create_election+x.#{authority.unique_id}" }
+    let(:message) { build(:create_election_message, message_id: message_id) }
+
+    it "broadcast invalid" do
+      expect { subject }.to broadcast(:invalid)
+    end
+  end
 end

--- a/decidim-bulletin_board-app/spec/commands/create_election_spec.rb
+++ b/decidim-bulletin_board-app/spec/commands/create_election_spec.rb
@@ -96,4 +96,12 @@ RSpec.describe CreateElection do
       expect { subject }.to broadcast(:invalid, "There must be at least 1 question for the election")
     end
   end
+
+  context "when the client is a trustee" do
+    let(:authority) { create(:trustee, private_key: private_key) }
+
+    it "broadcast invalid" do
+      expect { subject }.to broadcast(:invalid)
+    end
+  end
 end

--- a/decidim-bulletin_board-app/spec/commands/process_key_ceremony_step_spec.rb
+++ b/decidim-bulletin_board-app/spec/commands/process_key_ceremony_step_spec.rb
@@ -108,5 +108,14 @@ RSpec.describe ProcessKeyCeremonyStep do
     end
   end
 
+  context "when the message author is not a trustee" do
+    let(:message_id) { "#{election.unique_id}.key_ceremony.trustee_election_keys+x.#{trustee.unique_id}" }
+    let(:message) { build(:key_ceremony_message, message_id: message_id, election: election, trustee: trustee) }
+
+    it "broadcast invalid" do
+      expect { subject }.to broadcast(:invalid)
+    end
+  end
+
   # TODO: test race conditions
 end

--- a/decidim-bulletin_board-app/spec/commands/process_key_ceremony_step_spec.rb
+++ b/decidim-bulletin_board-app/spec/commands/process_key_ceremony_step_spec.rb
@@ -100,5 +100,13 @@ RSpec.describe ProcessKeyCeremonyStep do
     end
   end
 
+  context "when the client is the authority" do
+    let(:trustee) { election.authority }
+
+    it "broadcast invalid" do
+      expect { subject }.to broadcast(:invalid)
+    end
+  end
+
   # TODO: test race conditions
 end

--- a/decidim-bulletin_board-app/spec/commands/vote_spec.rb
+++ b/decidim-bulletin_board-app/spec/commands/vote_spec.rb
@@ -49,4 +49,12 @@ RSpec.describe Vote do
       expect { subject }.not_to change { Election.last.status } .from("vote")
     end
   end
+
+  context "when the client is a trustee" do
+    let(:authority) { election.trustees.first }
+
+    it "broadcast invalid" do
+      expect { subject }.to broadcast(:invalid)
+    end
+  end
 end

--- a/decidim-bulletin_board-app/spec/commands/vote_spec.rb
+++ b/decidim-bulletin_board-app/spec/commands/vote_spec.rb
@@ -57,4 +57,13 @@ RSpec.describe Vote do
       expect { subject }.to broadcast(:invalid)
     end
   end
+
+  context "when the message author is not a voter" do
+    let(:message_id) { "#{election.unique_id}.vote.cast+x.#{generate(:voter_id)}" }
+    let(:message) { build(:vote_message, message_id: message_id, election: election) }
+
+    it "broadcast invalid" do
+      expect { subject }.to broadcast(:invalid)
+    end
+  end
 end

--- a/decidim-bulletin_board-app/spec/models/authority_spec.rb
+++ b/decidim-bulletin_board-app/spec/models/authority_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Authority do
+  subject { authority }
+
+  let(:authority) { build(:authority) }
+
+  it { is_expected.to be_valid }
+
+  describe "#authority?" do
+    it "returns true" do
+      expect(subject.authority?).to be true
+    end
+  end
+
+  describe "#bulletin_board?" do
+    it "returns false" do
+      expect(subject.bulletin_board?).to be false
+    end
+  end
+
+  describe "#trustee?" do
+    it "returns false" do
+      expect(subject.trustee?).to be false
+    end
+  end
+end

--- a/decidim-bulletin_board-app/spec/models/trustee_spec.rb
+++ b/decidim-bulletin_board-app/spec/models/trustee_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Trustee do
+  subject { trustee }
+
+  let(:trustee) { build(:trustee) }
+
+  it { is_expected.to be_valid }
+
+  describe "#trustee?" do
+    it "returns true" do
+      expect(subject.trustee?).to be true
+    end
+  end
+
+  describe "#bulletin_board?" do
+    it "returns false" do
+      expect(subject.bulletin_board?).to be false
+    end
+  end
+
+  describe "#authority?" do
+    it "returns false" do
+      expect(subject.authority?).to be false
+    end
+  end
+end


### PR DESCRIPTION
This PR validates that the command is called by the correct Client and also ensures that the message author is the expected, otherwise it broadcast an `:invalid`.