### PR TITLE
Add support for vote verification

### DIFF
--- a/decidim-bulletin_board-app/app/graphql/types/log_entry_type.rb
+++ b/decidim-bulletin_board-app/app/graphql/types/log_entry_type.rb
@@ -7,6 +7,7 @@ module Types
     field :client, Types::ClientType, null: false
     field :signed_data, String, null: false
     field :chained_hash, String, null: false
+    field :content_hash, String, null: false
     field :message_id, String, null: false
   end
 end

--- a/decidim-bulletin_board-app/app/graphql/types/pending_message_type.rb
+++ b/decidim-bulletin_board-app/app/graphql/types/pending_message_type.rb
@@ -7,5 +7,6 @@ module Types
     field :client, Types::ClientType, null: false
     field :signed_data, String, null: false
     field :status, String, null: false
+    field :message_id, String, null: false
   end
 end

--- a/decidim-bulletin_board-app/app/graphql/types/query_type.rb
+++ b/decidim-bulletin_board-app/app/graphql/types/query_type.rb
@@ -50,5 +50,17 @@ module Types
         PendingMessage.find_by(id: args[:id])
       end
     end
+
+    field :log_entry,
+          Types::LogEntryType,
+          null: true,
+          description: "Returns the log entry with the given content hash for the given election" do
+      argument :election_unique_id, String, required: true
+      argument :content_hash, String, required: true
+
+      def resolve(_parent, args, _context)
+        LogEntry.find_by(election: Election.find_by(unique_id: args[:election_unique_id]), content_hash: args[:content_hash])
+      end
+    end
   end
 end

--- a/decidim-bulletin_board-app/app/models/log_entry.rb
+++ b/decidim-bulletin_board-app/app/models/log_entry.rb
@@ -7,7 +7,8 @@ class LogEntry < ApplicationRecord
   belongs_to :client, optional: true
 
   before_create do
-    self.chained_hash = Digest::SHA256.hexdigest([previous_hash, signed_data].join("."))
+    self.content_hash = Digest::SHA256.hexdigest(signed_data)
+    self.chained_hash = Digest::SHA256.hexdigest([previous_hash, content_hash].join("."))
   end
 
   def decoded_data

--- a/decidim-bulletin_board-app/db/migrate/20201207160752_add_content_hash_to_log_entries.rb
+++ b/decidim-bulletin_board-app/db/migrate/20201207160752_add_content_hash_to_log_entries.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class LogEntry < ApplicationRecord; end
+
+class AddContentHashToLogEntries < ActiveRecord::Migration[6.0]
+  def change
+    add_column :log_entries, :content_hash, :string, null: false, unique: true
+  end
+end

--- a/decidim-bulletin_board-app/db/schema.rb
+++ b/decidim-bulletin_board-app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_01_141644) do
+ActiveRecord::Schema.define(version: 2020_12_07_160752) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -60,6 +60,7 @@ ActiveRecord::Schema.define(version: 2020_12_01_141644) do
     t.string "message_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "content_hash", null: false
     t.index ["chained_hash"], name: "index_log_entries_on_chained_hash", unique: true
     t.index ["client_id"], name: "index_log_entries_on_client_id"
     t.index ["election_id"], name: "index_log_entries_on_election_id"

--- a/decidim-bulletin_board-app/spec/factories/models.rb
+++ b/decidim-bulletin_board-app/spec/factories/models.rb
@@ -47,7 +47,7 @@ FactoryBot.define do
     end
   end
 
-  factory :log_entry do
+  trait :message_model do
     transient do
       authority { build(:authority, private_key: private_key) }
       private_key { generate(:private_key) }
@@ -60,7 +60,11 @@ FactoryBot.define do
     signed_data { JWT.encode(message, private_key.keypair, "RS256") }
   end
 
-  factory :pending_message, parent: :log_entry, class: :pending_message do
+  factory :log_entry, traits: [:message_model] do
+    content_hash { Digest::SHA256.hexdigest(signed_data) }
+  end
+
+  factory :pending_message, traits: [:message_model] do
     status { :enqueued }
 
     trait :accepted do

--- a/decidim-bulletin_board-app/spec/queries/get_log_entry_spec.rb
+++ b/decidim-bulletin_board-app/spec/queries/get_log_entry_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "GetLogEntry" do
+  subject(:result) do
+    result = DecidimBulletinBoardSchema.execute(query, context: {})
+    raise result["errors"][0]["message"] if result["errors"].present?
+
+    result
+  end
+
+  let(:query) do
+    <<~GQL
+      query GetLogEntry {
+        logEntry(electionUniqueId: "#{election_unique_id}", contentHash: "#{content_hash}") {
+          messageId
+          signedData
+          contentHash
+        }
+      }
+    GQL
+  end
+  let!(:log_entry) { create(:log_entry, election: election, message: build(:vote_message, election: election)) }
+  let(:election) { create(:election) }
+  let(:election_unique_id) { election.unique_id }
+  let(:content_hash) { log_entry.content_hash }
+
+  it "returns the log entry information" do
+    expect(subject.deep_symbolize_keys).to include(
+      data: {
+        logEntry: {
+          messageId: log_entry.message_id,
+          signedData: log_entry.signed_data,
+          contentHash: content_hash
+        }
+      }
+    )
+  end
+
+  describe "when the election doesn't exist" do
+    let(:election_unique_id) { "foo.bar.1" }
+
+    it { expect(subject.dig("data", "logEntry")).to be_nil }
+  end
+
+  describe "when the log entry doesn't exist" do
+    let(:content_hash) { "test" }
+
+    it { expect(subject.dig("data", "logEntry")).to be_nil }
+  end
+end

--- a/decidim-bulletin_board-app/spec/queries/get_pending_message_spec.rb
+++ b/decidim-bulletin_board-app/spec/queries/get_pending_message_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "GetPendingMessage" do
+  subject(:result) do
+    result = DecidimBulletinBoardSchema.execute(query, context: {})
+    raise result["errors"][0]["message"] if result["errors"].present?
+
+    result
+  end
+
+  let(:query) do
+    <<~GQL
+      query GetPendingMessage {
+        pendingMessage(id: "#{pending_message_id}") {
+          messageId
+          signedData
+          status
+        }
+      }
+    GQL
+  end
+  let!(:pending_message) { create(:pending_message, election: election, message: build(:vote_message, election: election)) }
+  let(:election) { create(:election) }
+  let(:pending_message_id) { pending_message.id }
+
+  it "returns the pending message information" do
+    expect(subject.deep_symbolize_keys).to include(
+      data: {
+        pendingMessage: {
+          messageId: pending_message.message_id,
+          signedData: pending_message.signed_data,
+          status: pending_message.status
+        }
+      }
+    )
+  end
+
+  describe "when the pending message doesn't exist" do
+    let(:pending_message_id) { "test" }
+
+    it { expect(subject.dig("data", "pendingMessage")).to be_nil }
+  end
+end

--- a/decidim-bulletin_board-js/src/types.d.ts
+++ b/decidim-bulletin_board-js/src/types.d.ts
@@ -52,6 +52,7 @@ export type LogEntry = {
   __typename?: 'LogEntry';
   chainedHash: Scalars['String'];
   client: Client;
+  contentHash: Scalars['String'];
   election: Election;
   id: Scalars['ID'];
   messageId: Scalars['String'];
@@ -88,6 +89,7 @@ export type PendingMessage = {
   client: Client;
   election?: Maybe<Election>;
   id: Scalars['ID'];
+  messageId: Scalars['String'];
   signedData: Scalars['String'];
   status: Scalars['String'];
 };
@@ -107,6 +109,8 @@ export type Query = {
   election?: Maybe<Election>;
   /** Returns a list of elections in the bulletin board */
   elections: Array<Election>;
+  /** Returns the log entry with the given content hash for the given election */
+  logEntry?: Maybe<LogEntry>;
   /** Returns the information for this bulletin board instance */
   me: Client;
   /** Returns the information for a given message */
@@ -116,6 +120,12 @@ export type Query = {
 
 export type QueryElectionArgs = {
   uniqueId: Scalars['String'];
+};
+
+
+export type QueryLogEntryArgs = {
+  electionUniqueId: Scalars['String'];
+  contentHash: Scalars['String'];
 };
 
 

--- a/decidim-bulletin_board-ruby/spec/fixtures/bb_schema.json
+++ b/decidim-bulletin_board-ruby/spec/fixtures/bb_schema.json
@@ -387,6 +387,24 @@
               "deprecationReason": null
             },
             {
+              "name": "contentHash",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "election",
               "description": null,
               "args": [
@@ -658,6 +676,24 @@
               "deprecationReason": null
             },
             {
+              "name": "messageId",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "signedData",
               "description": null,
               "args": [
@@ -822,6 +858,47 @@
                     }
                   }
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "logEntry",
+              "description": "Returns the log entry with the given content hash for the given election",
+              "args": [
+                {
+                  "name": "electionUniqueId",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "contentHash",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "LogEntry",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null


### PR DESCRIPTION
This PR adds the content hash field to log entries and allow clients to retrieve a log entry by its content hash. This feature will be used to implement the vote verification described in decidim/decidim#5975. 
It also adds the `messageId` field to the PendingMessage GraphQL type and a test for the `pendingMessage` query.