### PR TITLE
Run all tests affected by PR

### DIFF
--- a/.github/workflows/app-workflow.yml
+++ b/.github/workflows/app-workflow.yml
@@ -1,9 +1,12 @@
 name: "[CI] Application"
 on:
-  push:
+  pull_request:
     paths:
       - ".github/workflows/app-workflow.yml"
       - "decidim-bulletin_board-app/**"
+  push:
+    branches:
+      - master
 
 env:
   CI: "true"

--- a/.github/workflows/js-workflow.yml
+++ b/.github/workflows/js-workflow.yml
@@ -1,9 +1,12 @@
 name: "[CI] JS Client"
 on:
-  push:
+  pull_request:
     paths:
       - ".github/workflows/js-workflow.yml"
       - "decidim-bulletin_board-js/**"
+  push:
+    branches:
+      - master
 
 env:
   CI: "true"

--- a/.github/workflows/ruby-workflow.yml
+++ b/.github/workflows/ruby-workflow.yml
@@ -1,9 +1,12 @@
 name: "[CI] Ruby Client"
 on:
-  push:
+  pull_request:
     paths:
       - ".github/workflows/ruby-workflow.yml"
       - "decidim-bulletin_board-ruby/**"
+  push:
+    branches:
+      - master
 
 env:
   CI: "true"


### PR DESCRIPTION
Current Github Actions configuration only run tests for the folders modified by the commits of the last push. This prevents executing the right tests if you push a new commit not affecting a folder modified in the previous commits of the same PR.

This PR changes this, executing the tests for all the folders modified by the PR, and running all the tests when pushing the changes to `master`.