### PR TITLE
fix: cast vote content changes

### DIFF
--- a/decidim-bulletin_board-js/src/index.js
+++ b/decidim-bulletin_board-js/src/index.js
@@ -1,4 +1,5 @@
 import { Client } from "./client/client";
 import { KeyCeremony } from "./key-ceremony/key-ceremony";
+import { Voter } from "./voter/voter";
 
-export { Client, KeyCeremony };
+export { Client, KeyCeremony, Voter };

--- a/decidim-bulletin_board-js/src/voter/voter_wrapper_dummy.js
+++ b/decidim-bulletin_board-js/src/voter/voter_wrapper_dummy.js
@@ -8,6 +8,6 @@ export class VoterWrapper {
   }
 
   encrypt(data) {
-    return data;
+    return JSON.stringify(data);
   }
 }

--- a/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/version.rb
+++ b/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/version.rb
@@ -2,6 +2,6 @@
 
 module Decidim
   module BulletinBoard
-    VERSION = "0.2.0"
+    VERSION = "0.2.1"
   end
 end

--- a/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/voter/vote_form.rb
+++ b/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/voter/vote_form.rb
@@ -29,9 +29,9 @@ module Decidim
           @message_id ||= "#{election_id}.vote.cast+v.#{voter_id}"
         end
 
-        # Public: uses the bulletin board client to sign the encrypted vote merged with the `message_id`.
+        # Public: uses the bulletin board client to sign the encrypted vote merged with the metadata
         def signed_data
-          @signed_data ||= bulletin_board_client.sign_data(encrypted_vote.merge(message_id: message_id))
+          @signed_data ||= bulletin_board_client.sign_data(message)
         end
 
         private
@@ -56,6 +56,14 @@ module Decidim
           return if voter_data.blank?
 
           voter_data[:voter_id]
+        end
+
+        def message
+          {
+            iat: Time.now.to_i,
+            message_id: message_id,
+            content: encrypted_vote
+          }
         end
       end
     end

--- a/decidim-bulletin_board-ruby/spec/decidim/bulletin_board/voter/vote_form_spec.rb
+++ b/decidim-bulletin_board-ruby/spec/decidim/bulletin_board/voter/vote_form_spec.rb
@@ -15,9 +15,7 @@ module Decidim
         let(:voter_data) do
           { voter_id: "voter.1" }
         end
-        let(:encrypted_vote) do
-          { question_1: "aNsWeR 1" }
-        end
+        let(:encrypted_vote) { "{ \"question_1\": \"aNsWeR 1\" }" }
 
         describe("when the election data doesn't include the election_id") do
           let(:election_data) do


### PR DESCRIPTION
This PR releases the v0.2.1 version of the gem with a small patch. In the `VoteForm` I assumed the `encrypted_vote` data was passed as a Ruby `Hash` but after a technical discussion we decided to stick to JSON for now.

I also added the `iat` attribute that was missing and made clear what is the message that we are signing.

For the JS part I fixed a small bug where I forgot to export the `Voter` class and finally decided to change the dummy implementation of that encrypt to return a JSON. This will simplify the `decidim` part as well.