### PR TITLE
fix: sign data was not using the correct private key to sign

### DIFF
--- a/decidim-bulletin_board-ruby/CHANGELOG.md
+++ b/decidim-bulletin_board-ruby/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2020-12-10
+
+### Fixed
+
+- Uses the correct private key in the `sign_data` method.
+
 ## [0.3.0] - 2020-12-10
 
 ### Added

--- a/decidim-bulletin_board-ruby/Gemfile.lock
+++ b/decidim-bulletin_board-ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    decidim-bulletin_board (0.3.0)
+    decidim-bulletin_board (0.3.1)
       activemodel (~> 5.0, >= 5.0.0.1)
       activesupport (~> 5.0, >= 5.0.0.1)
       byebug (~> 11.0)

--- a/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/client.rb
+++ b/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/client.rb
@@ -35,7 +35,7 @@ module Decidim
       end
 
       def sign_data(data)
-        JWT.encode(data, identification_private_key.keypair, "RS256")
+        JWT.encode(data, private_key.keypair, "RS256")
       end
 
       def setup_election(election_data)

--- a/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/version.rb
+++ b/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/version.rb
@@ -2,6 +2,6 @@
 
 module Decidim
   module BulletinBoard
-    VERSION = "0.3.0"
+    VERSION = "0.3.1"
   end
 end

--- a/decidim-bulletin_board-ruby/spec/decidim/bulletin_board/client_spec.rb
+++ b/decidim-bulletin_board-ruby/spec/decidim/bulletin_board/client_spec.rb
@@ -71,6 +71,14 @@ module Decidim
         it { is_expected.not_to be_configured }
       end
 
+      describe "sign_data" do
+        it "uses the private key to sign in the data as JWT" do
+          allow(JWT).to receive(:encode)
+          subject.sign_data("some-data")
+          expect(JWT).to have_received(:encode).with("some-data", instance_of(OpenSSL::PKey::RSA), "RS256")
+        end
+      end
+
       describe "cast_vote" do
         let(:election_data) do
           { election_id: "test.1" }


### PR DESCRIPTION
This fixes the `sign_data` method to use the correct private key. I also added the missing test to catch the 🐛 