### PR TITLE
New messages format

### DIFF
--- a/decidim-bulletin_board-app/Gemfile.lock
+++ b/decidim-bulletin_board-app/Gemfile.lock
@@ -293,6 +293,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap (>= 1.4.2)
@@ -336,4 +337,4 @@ RUBY VERSION
    ruby 2.6.6p146
 
 BUNDLED WITH
-   2.1.4
+   2.2.0

--- a/decidim-bulletin_board-app/app/commands/concerns/log_entry_command.rb
+++ b/decidim-bulletin_board-app/app/commands/concerns/log_entry_command.rb
@@ -33,7 +33,7 @@ module LogEntryCommand
           "Invalid signature"
         elsif decoded_error.present?
           decoded_error
-        elsif message_id != decoded_data["message_id"]
+        elsif message_id != decoded_data[:message_id]
           "The message identifier given doesn't match the signed data"
         elsif message_identifier.type != type
           "The message is not valid for this endpoint"
@@ -71,7 +71,7 @@ module LogEntryCommand
     end
 
     def invalid_timestamp?
-      iat = decoded_data.dig("iat")
+      iat = decoded_data[:iat]
       Time.zone.at(iat) < settings[:iat_expiration_minutes].minutes.ago
     end
 

--- a/decidim-bulletin_board-app/app/commands/create_election.rb
+++ b/decidim-bulletin_board-app/app/commands/create_election.rb
@@ -63,35 +63,35 @@ class CreateElection < Rectify::Command
   end
 
   def find_or_create_trustee(trustee)
-    Trustee.where(name: trustee["name"]).or(Trustee.where(public_key: trustee["public_key"])).first ||
+    Trustee.where(name: trustee[:name]).or(Trustee.where(public_key: truste[:public_key])).first ||
       Trustee.create!(
-        name: trustee["name"],
-        public_key: JSON.parse(trustee["public_key"])
+        name: trustee[:name],
+        public_key: JSON.parse(trustee[:public_key])
       )
   end
 
   def trustees
-    @trustees ||= decoded_data["trustees"]
+    @trustees ||= decoded_data[:trustees]
   end
 
   def title
-    @title ||= decoded_data.dig("description", "name", "text", 0, "value")
+    @title ||= decoded_data.dig(:description, :name, :text, 0, :value)
   end
 
   def start_date
     return @start_date if defined?(@start_date)
 
-    @start_date ||= Time.zone.parse(decoded_data.dig("description", "start_date") || "")
+    @start_date ||= Time.zone.parse(decoded_data.dig(:description, :start_date) || "")
   end
 
   def end_date
     return @end_date if defined?(@end_date)
 
-    @end_date ||= Time.zone.parse(decoded_data.dig("description", "end_date") || "")
+    @end_date ||= Time.zone.parse(decoded_data.dig(:description, :end_date) || "")
   end
 
   def questions
-    @questions ||= decoded_data.dig("description", "contests")
+    @questions ||= decoded_data.dig(:description, :contests)
   end
 
   def valid_election?
@@ -112,8 +112,8 @@ class CreateElection < Rectify::Command
 
   def valid_questions?
     questions.each do |quest|
-      number_elected = quest.dig("number_elected")
-      ballot_selections = quest.dig("ballot_selections")
+      number_elected = quest.dig(:number_elected)
+      ballot_selections = quest.dig(:ballot_selections)
       return false unless run_validations do
         if number_elected.blank?
           "There must be specified the number of answers to be selected"

--- a/decidim-bulletin_board-app/app/commands/create_election.rb
+++ b/decidim-bulletin_board-app/app/commands/create_election.rb
@@ -63,7 +63,7 @@ class CreateElection < Rectify::Command
   end
 
   def find_or_create_trustee(trustee)
-    Trustee.where(name: trustee[:name]).or(Trustee.where(public_key: truste[:public_key])).first ||
+    Trustee.where(name: trustee[:name]).or(Trustee.where(public_key: trustee[:public_key])).first ||
       Trustee.create!(
         name: trustee[:name],
         public_key: JSON.parse(trustee[:public_key])

--- a/decidim-bulletin_board-app/app/models/log_entry.rb
+++ b/decidim-bulletin_board-app/app/models/log_entry.rb
@@ -7,16 +7,20 @@ class LogEntry < ApplicationRecord
   belongs_to :client, optional: true
 
   before_create do
-    self.content_hash = Digest::SHA256.hexdigest(signed_data)
-    self.chained_hash = Digest::SHA256.hexdigest([previous_hash, content_hash].join("."))
+    self.content_hash = Digest::SHA256.hexdigest(content) if content
+    self.chained_hash = Digest::SHA256.hexdigest([previous_hash, decoded_data].join("."))
   end
 
   def decoded_data
     @decoded_data ||= begin
-                        JWT.decode(signed_data, client.public_key_rsa, true, verify_iat: true, algorithm: "RS256").first
+                        JWT.decode(signed_data, client.public_key_rsa, true, verify_iat: true, algorithm: "RS256").first.with_indifferent_access
                       rescue JWT::VerificationError, JWT::DecodeError, JWT::InvalidIatError, JWT::InvalidPayload => e
                         { error: e.message }
                       end
+  end
+
+  def content
+    @content ||= decoded_data[:content]
   end
 
   def previous_hash

--- a/decidim-bulletin_board-app/app/services/voting_scheme/dummy.rb
+++ b/decidim-bulletin_board-app/app/services/voting_scheme/dummy.rb
@@ -7,9 +7,10 @@ module VotingScheme
   class Dummy < Base
     def process_message(message_identifier, message)
       method_name = :"process_#{message_identifier.type}_message"
+      content = JSON.parse(message.delete(:content) || "null")&.with_indifferent_access
       if respond_to?(method_name, true)
         @response = nil
-        method(method_name).call(message)
+        method(method_name).call(message, content)
         @response
       end
     end
@@ -20,18 +21,18 @@ module VotingScheme
       @response = response
     end
 
-    def process_create_election_message(message)
-      raise RejectedMessage, "There must be at least 2 Trustees" if message.fetch("trustees", []).count < 2
+    def process_create_election_message(message, content)
+      raise RejectedMessage, "There must be at least 2 Trustees" if message.fetch(:trustees, []).count < 2
 
       @state = { joint_election_key: 1, trustees: [] }
     end
 
-    def process_key_ceremony_message(message)
-      election_public_key = message.fetch("election_public_key", 0)
-      raise RejectedMessage, "The trustee sent their public keys already" if state[:trustees].include?(message["owner_id"])
+    def process_key_ceremony_message(message, content)
+      election_public_key = content.fetch(:election_public_key, 0)
+      raise RejectedMessage, "The trustee sent their public keys already" if state[:trustees].include?(content[:owner_id])
       raise RejectedMessage, "The election public key should be a prime number" unless Prime.prime?(election_public_key)
 
-      state[:trustees] << message["owner_id"]
+      state[:trustees] << content[:owner_id]
       state[:joint_election_key] *= election_public_key
 
       if state[:trustees].count == election.trustees.count
@@ -41,8 +42,8 @@ module VotingScheme
       end
     end
 
-    def process_vote_message(message)
-      raise RejectedMessage, "The given ballot style is invalid" if message.fetch("ballot_style", "invalid-style") == "invalid-style"
+    def process_vote_message(message, content)
+      raise RejectedMessage, "The given ballot style is invalid" if content.fetch(:ballot_style, "invalid-style") == "invalid-style"
     end
   end
 end

--- a/decidim-bulletin_board-app/app/services/voting_scheme/dummy.rb
+++ b/decidim-bulletin_board-app/app/services/voting_scheme/dummy.rb
@@ -21,13 +21,13 @@ module VotingScheme
       @response = response
     end
 
-    def process_create_election_message(message, content)
+    def process_create_election_message(message, _content)
       raise RejectedMessage, "There must be at least 2 Trustees" if message.fetch(:trustees, []).count < 2
 
       @state = { joint_election_key: 1, trustees: [] }
     end
 
-    def process_key_ceremony_message(message, content)
+    def process_key_ceremony_message(_message, content)
       election_public_key = content.fetch(:election_public_key, 0)
       raise RejectedMessage, "The trustee sent their public keys already" if state[:trustees].include?(content[:owner_id])
       raise RejectedMessage, "The election public key should be a prime number" unless Prime.prime?(election_public_key)
@@ -42,7 +42,7 @@ module VotingScheme
       end
     end
 
-    def process_vote_message(message, content)
+    def process_vote_message(_message, content)
       raise RejectedMessage, "The given ballot style is invalid" if content.fetch(:ballot_style, "invalid-style") == "invalid-style"
     end
   end

--- a/decidim-bulletin_board-app/db/migrate/20201207160752_add_content_hash_to_log_entries.rb
+++ b/decidim-bulletin_board-app/db/migrate/20201207160752_add_content_hash_to_log_entries.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
-class LogEntry < ApplicationRecord; end
-
 class AddContentHashToLogEntries < ActiveRecord::Migration[6.0]
   def change
-    add_column :log_entries, :content_hash, :string, null: false, unique: true
+    add_column :log_entries, :content_hash, :string, null: true, index: true
   end
 end

--- a/decidim-bulletin_board-app/db/schema.rb
+++ b/decidim-bulletin_board-app/db/schema.rb
@@ -60,7 +60,7 @@ ActiveRecord::Schema.define(version: 2020_12_07_160752) do
     t.string "message_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.string "content_hash", null: false
+    t.string "content_hash"
     t.index ["chained_hash"], name: "index_log_entries_on_chained_hash", unique: true
     t.index ["client_id"], name: "index_log_entries_on_client_id"
     t.index ["election_id"], name: "index_log_entries_on_election_id"

--- a/decidim-bulletin_board-app/spec/commands/process_key_ceremony_step_spec.rb
+++ b/decidim-bulletin_board-app/spec/commands/process_key_ceremony_step_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe ProcessKeyCeremonyStep do
   end
 
   context "when the data is invalid" do
-    let(:extra_message_params) { { content_traits: [ :invalid ] } }
+    let(:extra_message_params) { { content_traits: [:invalid] } }
 
     it_behaves_like "key ceremony fails"
 

--- a/decidim-bulletin_board-app/spec/commands/process_key_ceremony_step_spec.rb
+++ b/decidim-bulletin_board-app/spec/commands/process_key_ceremony_step_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe ProcessKeyCeremonyStep do
   end
 
   context "when the data is invalid" do
-    let(:extra_message_params) { { election_public_key: 4 } }
+    let(:extra_message_params) { { content_traits: [ :invalid ] } }
 
     it_behaves_like "key ceremony fails"
 

--- a/decidim-bulletin_board-app/spec/commands/shared/log_entry_validations.rb
+++ b/decidim-bulletin_board-app/spec/commands/shared/log_entry_validations.rb
@@ -6,6 +6,7 @@ RSpec.shared_context "with a signed message" do
   let(:signed_data) { JWT.encode(payload.as_json, signature_key, "RS256") }
   let(:payload) { build(message_type, **message_params.merge(extra_message_params)) }
   let(:message_id) { payload["message_id"] }
+  let(:message_params) { {} }
   let(:extra_message_params) { {} }
 end
 

--- a/decidim-bulletin_board-app/spec/commands/vote_spec.rb
+++ b/decidim-bulletin_board-app/spec/commands/vote_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Vote do
   end
 
   context "when the vote message is invalid" do
-    let(:extra_message_params) { { ballot_style: "invalid-style" } }
+    let(:extra_message_params) { { content_traits: [ :invalid ] } }
 
     it "broadcast invalid" do
       expect { subject }.to broadcast(:invalid)

--- a/decidim-bulletin_board-app/spec/commands/vote_spec.rb
+++ b/decidim-bulletin_board-app/spec/commands/vote_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Vote do
   end
 
   context "when the vote message is invalid" do
-    let(:extra_message_params) { { content_traits: [ :invalid ] } }
+    let(:extra_message_params) { { content_traits: [:invalid] } }
 
     it "broadcast invalid" do
       expect { subject }.to broadcast(:invalid)

--- a/decidim-bulletin_board-app/spec/factories/messages.rb
+++ b/decidim-bulletin_board-app/spec/factories/messages.rb
@@ -22,13 +22,17 @@ FactoryBot.define do
     "voter-#{n}"
   end
 
-  factory :json, class: "ActiveSupport::HashWithIndifferentAccess" do
+  factory :hash, class: "ActiveSupport::HashWithIndifferentAccess" do
     initialize_with { ActiveSupport::HashWithIndifferentAccess[**fix_reserved_names(attributes)] }
     skip_create
 
     # Warning! All transient parameters should have a block to prevent them from
     # being added to the hash
     factory :message do
+      transient do
+        content_traits { [] }
+      end
+
       iat { Time.now.to_i }
     end
 
@@ -144,111 +148,69 @@ FactoryBot.define do
       end
 
       message_id { "#{election.unique_id}.key_ceremony.trustee_election_keys+t.#{trustee.unique_id}" }
+      content { build(:key_ceremony_message_content, *content_traits, election: election, trustee: trustee).to_json }
+    end
+
+    factory :key_ceremony_message_content do
+      transient do
+        election { build(:election) }
+        trustee { election.trustees.first }
+      end
+
       owner_id { trustee.unique_id }
       sequence_order { election.manifest["trustees"].find_index { |trustee_json| trustee_json["name"] == trustee.name } }
-      auxiliary_public_key { "-----BEGIN PUBLIC KEY-----\nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA6HhvGDSiKTN+Osb7m+Gt\nAKFzr00lrkN5PWvZXcQxO27VGe/007fH3w7okKszJdv4Rsc5Cu+Xf4F4EQhN2H3q\n9YT4Rck7KpnHX7RaktV8yhJb7O7+O6wLt9/AzLbHkGYJlnIJMHpG6bbL300kGmhI\nSqHzNikSTqJytkrjjgL3nL7AQXq6DGOzpn7DfIBlnZq6vdWDgT0Eqwc7FxPFHyxM\nYUBl86EjhPpvonfAVWlk9Wp55dpeXbI2JsI1uaJliQcJF5bWJcx03QbEMcvs4HUT\nBbku/qSklfuHc96ebGBMgzM7Qyp5DY5HWSg2x+tF0v5j1+ZALKrJcQgnNj3IaTzc\nG3prvjaWbUwdJLBkRD7Fz112ZatS0K/kbf17OZW254wFXuHx3/DCl0r/XXI4PFeR\nWzfGFga6OKRd5dJxpwVbJ38+t53IQPA94OIn/4Ly8n1KtKawzXwFg6+p1ALUAw/Y\nJiwOBeoVrt/ChMvl+fLLH5TLNnhFkF2C9Is2dM+Q0wEc9sTkIYT9TOGfDrIvJOk9\nO0LIdj/ojB9aNkZB6A90m1QtpjYRpza+OG3uMNsjC4xd7w28vjs6EQPK+eKcPQ44\nA/xoJoAZ735k9qMYRz9RCK52TqdTwWFUfvg+Rrh9g9s0I7tNNcgxUSYFY51WWL1+\n9VxP6xd8EJVFheoyHc6P5isCAwEAAQ==\n-----END PUBLIC KEY-----\n" }
       election_public_key { 3 }
-      election_public_key_proof
 
       trait :invalid do
         election_public_key { 4 }
       end
     end
 
-    factory :election_public_key_proof do
-      challenge { "7ER1o3ZlShoCD8Okg5Q6uaUAJUpL1l7SdD4pg6CkAw8=" }
-      commitment { "pl8zhjfiBLMCm/IgqapjuvmiU0d1EmfOANkf+ld3+R+EqWLZQ0K4l3Ae3Dv3ipP2dgKqNv/wGe61ZoRvhFGkQJnxXo/nFH3OR9bwqZLHpv6ZYeSX3ajD/f+M7nFUCbxDyZvlZYcPLcr2LSgFPXyKDr9tqpazpkQBo44ztZDIe1llv+aaxoiJP/A36IO0bVGKDG2BEU99+qUPMk8rxzaahI3u7yhI8MOC2FJUWTWwTZgnWsV2DnduGaW2cipCG1mbs3OfqHTodl10rOeLngw9CyybfvZdp0YIv1WLGO6S5jadJBYhptUCpamLW0C5pVpCG8uvTaR28kKS9h0NqEu6qa8g5Ow5bKrfxV2vb9SH4Ut1+2+9HqPyjGN16jKMIT79ZCu1iEEN2+RUw9K0rdRaqhKcOY9imLeHk8L5D0GJpR5MYgluFCmDl/+YDZbzE/m165OPiirqlSpY9gn9jCflDuXx9gR/kqsw28z1ImYo7eBDRPG2tQGgExibhycK4SLxPBL3nvYwtlrvd0EtP7eyA6Wb1RotJ92snSH5J5SleNBNCFEWm6cnlGGJ5el/2/kG/jcDVXLz4V02s6+FTbWXTF6s9mOg9Jp65av/T2umlfWvgT/r72AGyOn4hQtI9aGdyv7xPxyU7iiZa2h7BUpEQ3R5F2CO8NmBpdS0m5VEfrA=" }
-      name { "Schnorr Proof" }
-      public_key { "UxmYOgII7XfkqtmIhkm2I3W5g83recLynlu+z6qK9/iSyB1hW+H7j7KpKnd+pLAOCnxrKA7Kglxk4x5jQdXfYRhiTkL9TzIhejVoXpFFEqH8I1+8mPCYMPY1GxBhZodbAl3CRSIRqS7IMQfFZ6gtZFjrij5P70SuXYyI+K2igVcQuG1BK8CKFXpzDxiKhbVltIjNk4un8K48lTkNqH+nyJ+GQiBUi+x2/gGxgF6naQO9Z/ZAgTcECf9J7LnPxY/0iFkAyJsQiyDpktPCVfy5aAfUYwbDxatIIoE7ujKXyxrbEHPu+VtX3GvLRb53kPp8Wuh3b8eDSagwmh4Fa/yHpcfq1CJSGT4C4K55VbtQ1PcMTQyGJEtgBjpU/3XGyLK1TarnmFlZonKRiuYhHMLKmj4E1F5jaJ12/AwS+jXjTASZwMHgVdflkMCH/rceutcLTKtISNtZdGmP9JcnQ1uOCr1EQe/2sTlz1M8YzvupoPtBUE9ZtgvxGzPKx+tldJQv1cqVsAYTmEL3McUFeK3YLa5819kAOdZ/1tGy3pk3mIRdbiD1GFyiW3MEOwEAKVikIxninC0TwIw0ZiKh5C6YP3mOTN2C8zmWle1uPihO7XLK0f4TKC0pyCMXklkyZa05ZmjWgctJ17RWjLE1boNVTFwFOmy3ASErzDGbJtu9g8A=" }
-      response { "puH3SmTJnSn4JL3uDM5exiB0mDa67vibiu3qkA8IbCM" }
-      usage { "SecretValue" }
-    end
-
     factory :open_ballot_box_message, parent: :message do
       transient do
         authority { build(:authority) }
         election { build(:election) }
-        voting_scheme { :dummy }
       end
 
       message_id { "#{election.unique_id}.open_ballot_box+a.#{authority.unique_id}" }
-      scheme { build(:voting_scheme, name: voting_scheme) }
-      description { build(:description) }
     end
 
     factory :vote_message, parent: :message do
       transient do
         election { build(:election) }
         number_of_questions { 2 }
+        voter_id { generate(:voter_id) }
       end
 
-      message_id { "#{election.unique_id}.vote.cast+v.#{_object_id}" }
+      message_id { "#{election.unique_id}.vote.cast+v.#{voter_id}" }
+      content { build(:vote_message_content, *content_traits, election: election, number_of_questions: number_of_questions).to_json }
+    end
+
+    factory :vote_message_content do
+      transient do
+        election { build(:election) }
+        number_of_questions { 2 }
+      end
+
       ballot_style { "ballot-style" }
-      contests { build_list(:contest_ballot, number_of_questions) }
-      _object_id { generate(:voter_id) }
-      previous_tracking_hash { "" }
-      timestamp { Time.current.to_i }
-      crypto_hash { "bjISpYYhG+uthocLKA5wjOFdHPVo34xby8vz3RWj7BY=" }
-      description_hash { "7dS66G9hBgVu+fIrx61sJDCECgU9UIawwy+RWi8xR9s=" }
-      tracking_hash { "Cq6aF8l4dDCtuaptvyZ+Ej+Cep90CPPysVH4orucwoY=" }
+      encrypted_vote { {} }
 
       trait :invalid do
         ballot_style { "invalid-style" }
       end
-    end
 
-    factory :contest_ballot do
-      transient do
-        number_of_answers { 2 }
+      after(:build) do |content, evaluator|
+        content[:encrypted_vote] = Hash[
+          evaluator.election.manifest[:description][:contests].map do |contest|
+            [
+              contest[:object_id],
+              contest[:ballot_selections].map do |ballot_selection|
+                ballot_selection[:candidate_id]
+              end.sample(contest[:number_elected])
+            ]
+          end
+        ]
       end
-
-      ballot_selections { build_list(:selection_ballot, number_of_answers, contest_id: _object_id) }
-      crypto_hash { "INc1UrKLWxwaVjup1Vv+nW4GCdWsb1+hNGzlBeZpRUI=" }
-      description_hash { "zRhfoa+0QfJYxeAyBST7TF7+ApGlwQUyGifvlT798/0=" }
-      _object_id { generate(:contest_id) }
-      proof { build(:contest_proof) }
-    end
-
-    factory :contest_proof do
-      challenge { "1A1ZjlenxRKLSf6o0to2+fVkGoAIl4Z5DQSV4691GfI=" }
-      constant { 1 }
-      data { "/bB0vydnOyyn2KgsH0QmGvffhDv2X2cD92DQ1ZDnJbgjjfeDNRkv0DGGDYHuatLsXcdcEkH00PFvr92SrLOuqRK5ar4x1PMaAbReqzOn7khNnS64zOI+abiyefg704zPWDb73Mmp8VdAY0M+Z/zxGmMgvIqNannGK+bd55CND7l8KgIfkOLhqyKqtL72uH4fbZjivfpHG1Z2hV/JtaSou3HoET50+4A5JkwzgrMdMPNO/AOO7KixcOYNUZNu/AU4pW0S0R8/W3aSgLnEHPt2bC3WHlhPskjn4Q9G2cJBnhOBoJ1QM3hkDKx/FnBBpkcWLEuq98rFUXrYxrQiJNHBdbTKk30EAYc+K1JHiIkmhodmQ/tjCRR2YPgVgjnlrByHgZU6jkO2UZ16eGXrJx9EfG7+J02/69qE5BOoWCYae14WlR+2ZMjC80XqgNtcrjpgU2Oq+yOUpFshLkuHf5DXraDmF4VStK7uYjDRmBhrxNMWoWUy+RQeaQM68Vns/yU9h09YU6rhw3lcfM/nPjE40msnoozR9r4rCT1E4gOqKGFqz8HxM07DZ2iKJTj+sw3Lx3XAXWQ/0BIFyUTnIAr20ax1n6j4k6ZIc91ai3dvaNfHb7ngt/vscjcmhEVI4JUPlanGd4CRdCfIHiF/gBvqVHLucheM3pLAFh7mZKxElxc=" }
-      name { "Constant Chaum Pedersen Proof" }
-      pad { "yo4Xsd4W5ddd5KRT44/VMB1vFahfbhYVrA1gz6c9KWUohwR1ygMBwFHNgN+jfwqGKefSP1KzY9YTQTsARIRXdmfdxzMs7EIa5ylKmcBqP2BnC5l1WOJb+/NRXfltN1RNtx8gSICZ0rYIAcoqBVZJShTQRvZ2SUPDwhcw78wJJkFm3pMz9fH3/UCW+7c6iY1E6+cT/hi6m/3VaLGqVWMNTujrJo27FZp1cETNvCo9EKpJUYaWC5F3S4C1q9QFlwG5HOE2EsxrNyUiIxYhFi9YGt/mmXcASWjzck6lzQt92RO4U7I5t/B6jeq7Xx5hjbULbQtj/bdSAc4983TyCnLVjXE3EZwYoCLoNRg/biLBDIEOO6OPrfBmJoND5xdP50aoKmzjnj/Pg9Jns34cqc/S5DeVReiRMMuZ9R9eAiClu0IXKxORvWeD14RByoHUXI1KhGfV6DNyCmTXIVFbvJqVbFkqY60TVRqOwXRg9VozY7oG1f6KhGWqP4ZIXtYUlCO53hAIxh6DyMO1mVJ7/Ddqusc59O6916RJmdHUkKm0VZXEn3CBOTXkLRclb0LmdQ3559x1/HzY7Z6FsMsXQi7UMCaGW28TJFmj7x4XqXVUSyvxrrCeO8q3AuGkfgJjn+y02AjjIBFuEwSIDvxxqy+P5divFktS9p86qeVM8n5ax1Y=" }
-      response { "KhC1tJ3j86JL6uXICZTgBtyNP5U2GLrrKChKwbiszi0=" }
-      usage { "SelectionLimit" }
-    end
-
-    factory :selection_ballot do
-      transient do
-        contest_id { generate(:contest_id) }
-      end
-
-      ciphertext { build(:ciphertext) }
-      crypto_hash { "eZgMl6CRoLl1CJoMdOp/VUoN5qi0pVOegxFJS7QqauM=" }
-      description_hash { "c3MK/rIvA4poNcCvYKo+q4nww/SJ68nXaIoJjM3lQ9c=" }
-      is_placeholder_selection { false }
-      _object_id { "#{contest_id}-#{generate(:selection_id)}" }
-      proof { build(:selection_proof) }
-    end
-
-    factory :ciphertext do
-      pad { "samP9YzYLsSPBbhWr1jacr9FH9s4QrfLJcKSei48uFNf11STB+D18cEt5Hj523dkStJ61oGw9V6P6l82bpRk9KI5KhhAX9hS04lnSVx4zoY9CXzyROCExjnisc0sG10NL5GJZz0gNQXDO/KobRzG8OnucgZrX7Hk2otCF4ySeLEkgPSbA63V9f0460CCnbbZTk8CdhWOWzjN/Gk+0F1yLmdYZMs2SDVKCW0HISpzuBShEIJmQ1jRI9AwFoXuDKT+Mi5buanZuc5Zf5ApX8OY+Rh/x/MHQFNtDNa5ZGHEI1sWBBTPHXIBl8SCrRzSUVX6wCOMQyCtm/zLK3PMAizWE/eg8m87rp7tXNHy3kdAE5+joQ0egeITyPvmRpwXDc63rOBJ6p6AzMaz3Q+z0vntKwEXLuyLGzr0u+bR3lKf2j0LBAa2bWEUk2Junw+pHvQKvJiZ2NlppC3QJ3EFBdS/jblnIRlTDvu5CUTpwCwa6Q5hCp/S8RtWEef5eJ0dIi+Ws3NcAw799VrGVfn/ekhWNDBdZmOl9oJ9cX0e8NRyV9/pCgLFpQnZuSKN6NJFZfBXQetUAnYde8b6qIgrfGr3lfJSiEPZOTPxDvYvPkepCPCcYtlhJTH64zheO053az5G670Y9vveY5/tjHKGb47FYMPcN30/nuQvX/7WKF09zNM=" }
-      data { "JSiqgi+D4L2FbbaG41+m3ARFN+V1Kk8eepJsiPacMxJYWGbOQ/n7uFzx1XoZOGM/9B34GapQQGC92LQljSct0cGVP+sBFpiUJAc1GckKVZlYHCveTb2NEfnBVjC6qxupua0E+b1oVjzBLg2WDkizyTs2KPDAboImQjCUAETohabUme5hVqk9AtafW5WLIXWWN4To8v0bpL3RwlHaFd5//I9axsPMEQ5WLdP0akQXeB4ADaes43L25RGadZylmTpoPbQcWnXbu4oKlBq1U6jTzghyOV3nAyFAe4mRYcJav0Afy0ZQXc2yirsK7iuNfiYd2fE4GFOYKOkLy+67U4qNdT30H/yQUThzDEWyVeQMKCqaRYd5ynwOHBQ7PdVg0MGEbCAdDqAP+TigFDZgk6URhieDpAnWcMbePkA4qy9LS5bomQUjWF/+tYmb+0v+Dw8adpHsn5TgByVVHsAYLecaoifl3louSF6/8PKdFswNB5iemOGEcpOgTJMIr1QDr746LdA+V7W2Rt1+fVOKI9HWbx1+CvOrJA7C012dej27TDzBnHpfpuZTM2FyPSNOAxe3Hg1hK3luxl3k5MbizRjkqKam/TbfOK1CBNnEHRDzO289sjM+6G523KE+5IHvDiex/fD91om+Ez2kia4UX+DO9uTQ/u8hEWJNtE1ges6csIE=" }
-    end
-
-    factory :selection_proof do
-      challenge { "A81KTDONsn4ivK5iB1/u5kYS27SYBDAfYJUaU2xUYBo=" }
-      name { "Disjunctive Chaum Pedersen Proof" }
-      proof_one_challenge { "kEvG8XTr9rLVV1Xh9TaF0SvpUwR+yOe5zVAJXIYlAto=" }
-      proof_one_data { "gLhJIkPAz4Yy62GX2XLnWLYu9tlSAJzOBoU5RF1Qan+VsrBfpsxMeQHfmEnF36/yW37u1hYicRXvfHSsBxoVw3l68PDYDZ0nPlo+APTPmVvPOiF764HS3bVdGSkEwkxfKZSqAJ2yNUl8racMXzVa8m3Ny7fc4t/yXdsp0H+JY7VasJ2fD2NqlijFLSluzfPKyo8cuf3r7JVxL9jJxjTcNkUcp+LaJcUIKETydPA4WNrSlEPbj0Uu77Ia9ygChgK80AM1vkwrH2vXYKSsazQyGbx0tnRAKxtkclug0yKTtYe41EmXDK8f4i3krI7fX9Atv6xYMhEGo1xapYtKBZB3R6h2WPyVVOfgvAq2Sak1y6L3dM17/wAZGAeojGQAVJLR0jRbK0B5GtQkezSy51pNr8+DBrQf8EVWOBulo84r5mooCXqePF7o9RusWZiEReXX1y0P0ATzZYnaXjnUA3WClIxuiV5VbOHhtXxMYKs3P77oAvCX5MGTj3NfAmuHTpkCtRy9wrCsfJ9nsytzsqYgWJ0KcVNsm9mqD7ne0l3/QvZlIH7mvDOkuh+5aMkeUdKxsICW4vvHU+bcaaK0i91balMUuodcCKbZ3nbaaMxYOgYrOHY2ejYzW9TjpbqUZQ7bqBaWu3xzL/K/XpaZVMDdMpOgcJi+yg/0CkjzGKIwkJs=" }
-      proof_one_pad { "jYgXpGTOAnsrd444I0ZXX+hHLOHYKPv0wqv/1X5mCLZQ0uj5EfDNVO3XKHz8mipc06mNljdz/LsdCIAkRfZO2qFuftonZ510a/T52myy9QgZ11DwfjNujoL5Mz0CPRV1ez1gK+FVmdczWu7exZm7mlDzFCcdPFPyzc0/qkEU5kJEEny+PC9ewoGkj+wtm/aMxDx6KrrPAcF809Pp4vln0Hndh6pb3a6RJJJYf8Niapb94X6t59CL/0Wn4BzSPVHTZDRTK6GT0Rxzdd7mxVBVj+27hfYo7GSgY9dNA1DeCcwbJT63QJBb7boXzppKcOMBJpIWgpxpbX4RdU82tpdGVzTrFV8rWsXxrDpTQLuPo3A2Am8reGdoLu8vkkkzAY0vBcIOQExdXEs9W5sDxsLtovai9baqoNO9RSTLxiBSq80lg7FJEEWMJXnUhp8cHoNvKQNnczD/OqBtLBeec1+Amj8rk+VSu+YRIMgo368waU6c12xz7LtfoY0OSkhaVQKUnjWDwZvmLDJ5C8gFEuGpXRVKA7Yr49BClevPZcdTVuvq8qG7/LAKKwCdpLQVCYev3+OzypLQP3uWhhYchQfZQV59uv8AO9hbExCqj9qzc+oJSoPAZNmsmeLiUcrnCjGqF9yl1UJZlfSFf70K4guY8IdVHmUopPO2N7c7n5hOzGc=" }
-      proof_one_response { "eCGz+a1v+0jRHnSpXvpp6GggMKmniKxwSB4m9csBPNg=" }
-      proof_zero_challenge { "c4GDWr6hu8tNZViAEilpFRopiLAZO0hlk0UQ9uYvXIM=" }
-      proof_zero_data { "RP4KwGkNLqwUDiCa3ev+Vwx9u4EODFAxUE6OW2ANcHmLC7XeEO2uxI+qaLYdw7d2j2vA4CYzTzLXwFemEVCQXif/JxPzUwEXfIrFk0jc+EcY3ah3sM+gdT+3DeF+rerttNzLmlQpH5PyLb73qLsAk90xf0q36mzfSrpW00MN3/8y30dLKG3tAKEJtmE98lDdy6Vv7e7dk1bZmrgfggV5mzMV17MgHtHSusNdazMG5M7vx5SXRwycOGO02q88NrBwDsjF9B9/tucfO9C7mPHMbeDwglTRMm76SPDGym4ETcQiR88C4CUk6G6TzKe9Nf5YCIiR+glIbEtvy9NhazCEdSH4ETtVTF55AWPn306PxCX6jcgmzlHx9faWcx+DcBTXdZYJVClOH7gsg3apVEWrmdkz+nAnEONyqWNP9Mjw2d4gsSgOi/Q6aTbUvejVaVI9A9H/iPR5L/hwvVIgCJoWfET2kfxHdGanqtQBrJu5fL5BYMOTSOYEsB6P7jaE+Pevz5qfrJsyypVJ237XTDxii3qPrbAm0gUSbnu38zNPFAGN7M0WixL7qAWz+pKshClQ1wGikR3EJ+6leaau4Kg29+Ck3t4BywceGWXNucfg7SdkvupzAfTfAhz9DkTo7/rB8RzkqpT8wULwg1fQiubjVKZBPM6YHe9ABj1+1jvnuPc=" }
-      proof_zero_pad { "piFkW3bZFkBIFn45TTDK/GqjseMv+qoPeY4xyYqpKVtzSfqe/YaBjdyRxMGbJTWp3GoEN+vxbGK9tMwkKaiiwy8QRVJIL4wEeBEsdoI2RXf/hUkhFzRws3ITLbw+mkOuePWo0as0JVyfKNUdFPftNGlZwTrVKR3oP8BXqESUkHzrQlWujSKPZPII/5tLpid0fi/uj27pZqiwA8PCqPP9FnEXvFmF1dq7xG/OtbyTfRVOQctnbHJmqlZjKffo2PiYytP+7lncvoUdmA1SKaNEMz4Q51sKjuBR4lfOemZhj1pw75W4M6sQqA/abr6p4zwScrr1SjsCnVbQ0j35Or4ZNFZWxyRToU9Ri3pnYe0GR+KTbnHSRxUyfMd7DrypSZ/28w7n7cA/+HHpUUOrYigry5UDCHzKbPk9QrqrB2xUwtJJIx8FxAwKXafm7D0dLM172YXS92pCNotMMjzU2Of45f/aqrSgljVWNgFBpYGb62GuLXyyrxjQnvh9PDjgO0HxltFo19ZvrQJq55g8wEhaOfgwHNuoH/Di8TZ9GG8su+mKDio/qlKjG5NOBl12i/ks3zDSZW6PQ4cEGhjqZb/BxsB8u6lJf490irfuW7zbvKbzzUumhW+aIW9K+xdB2lZBdpCmc2zRywsng16IoQRED42dBeu5XSocu564Tw20Z5U=" }
-      proof_zero_response { "Jtb2ECiDdfcnA1WShU1BiDjd/WC+seU18AyBgrurgIM=" }
-      usage { "SelectionValue" }
     end
 
     factory :close_ballot_box_message, parent: :message do

--- a/decidim-bulletin_board-app/spec/jobs/process_key_ceremony_step_job_spec.rb
+++ b/decidim-bulletin_board-app/spec/jobs/process_key_ceremony_step_job_spec.rb
@@ -10,14 +10,15 @@ RSpec.describe ProcessKeyCeremonyStepJob do
   let(:trustees_plus_keys) { generate_list(:private_key, 3).map { |key| [create(:trustee, private_key: key), key] } }
   let(:trustee) { trustees_plus_keys.first.first }
   let(:private_key) { trustees_plus_keys.first.last }
-  let(:message) { build(:key_ceremony_message, election: election) }
+  let(:message) { build(:key_ceremony_message, content_traits: content_traits, election: election) }
+  let(:content_traits) { [] }
 
   it "processes the message" do
     expect { subject }.to change { PendingMessage.last.status } .from("enqueued").to("accepted")
   end
 
   context "when the message is rejected" do
-    let(:message) { build(:key_ceremony_message, :invalid, election: election) }
+    let(:content_traits) { [:invalid] }
 
     it "rejects the message" do
       expect { subject }.to change { PendingMessage.last.status } .from("enqueued").to("rejected")

--- a/decidim-bulletin_board-app/spec/jobs/vote_job_spec.rb
+++ b/decidim-bulletin_board-app/spec/jobs/vote_job_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe VoteJob do
   end
 
   context "when the message is rejected" do
-    let(:message) { build(:vote_message, :invalid, election: election) }
+    let(:message) { build(:vote_message, content_traits: [:invalid], election: election) }
 
     it "rejects the message" do
       expect { subject }.to change { PendingMessage.last.status } .from("enqueued").to("rejected")

--- a/decidim-bulletin_board-app/spec/mutations/vote_mutation_spec.rb
+++ b/decidim-bulletin_board-app/spec/mutations/vote_mutation_spec.rb
@@ -27,7 +27,7 @@ module Mutations
       GQL
     end
 
-    let!(:election) { create(:election, authority: authority) }
+    let!(:election) { create(:election, authority: authority, authority_private_key: private_key) }
     let(:headers) { { "Authorization": authority.api_key } }
     let(:authority) { create(:authority, private_key: private_key) }
     let(:message_id) { payload["message_id"] }

--- a/decidim-bulletin_board-js/src/client/message-identifier.js
+++ b/decidim-bulletin_board-js/src/client/message-identifier.js
@@ -1,14 +1,18 @@
+export const AUTHORITY_TYPE = "a";
+export const BULLETIN_BOARD_TYPE = "b";
+export const VOTER_TYPE = "v";
+export const TRUSTEE_TYPE = "t";
+export const VALID_TYPES = [
+  AUTHORITY_TYPE,
+  BULLETIN_BOARD_TYPE,
+  VOTER_TYPE,
+  TRUSTEE_TYPE,
+];
 
 /**
  * This is a class that handles message id strings.
  */
 export class MessageIdentifier {
-  AUTHORITY_TYPE = "a"
-  BULLETIN_BOARD_TYPE = "b"
-  VOTER_TYPE = "v"
-  TRUSTEE_TYPE = "t"
-  VALID_TYPES = [AUTHORITY_TYPE, BULLETIN_BOARD_TYPE, VOTER_TYPE, TRUSTEE_TYPE]
-
   /**
    * Parses a message id string into a JS object.
    *
@@ -16,12 +20,11 @@ export class MessageIdentifier {
    * @returns {Object} - An object with the message id values.
    */
   static parse(messageId) {
-    [elements, author] = messageId.split("+")
-    [authority, electionId, type, subtype] = split(".", 4)
-    [authorType, authorId] = author.split(".", 2)
+    const [elements, author] = messageId.split("+");
+    const [authority, electionId, type, subtype] = elements.split(".", 4);
+    const [authorType, authorId] = author.split(".", 2);
 
-    if (!VALID_TYPES.includes(authorType))
-    {
+    if (!VALID_TYPES.includes(authorType)) {
       throw new Error("Invalid message identifier format");
     }
 
@@ -32,12 +35,12 @@ export class MessageIdentifier {
       type_subtype: `${type}.${subtype}`,
       author: {
         type: authorType,
-        id: authorId
-      }
-    }
+        id: authorId,
+      },
+    };
   }
 
-  static format(electionId, type_subtype, authorType, authorId){
-    return `${electionId}.${type_subtype}+${authorType}.${authorId}`
+  static format(electionId, typeSubtype, authorType, authorId) {
+    return `${electionId}.${typeSubtype}+${authorType}.${authorId}`;
   }
 }

--- a/decidim-bulletin_board-js/src/client/message-identifier.js
+++ b/decidim-bulletin_board-js/src/client/message-identifier.js
@@ -1,0 +1,43 @@
+
+/**
+ * This is a class that handles message id strings.
+ */
+export class MessageIdentifier {
+  AUTHORITY_TYPE = "a"
+  BULLETIN_BOARD_TYPE = "b"
+  VOTER_TYPE = "v"
+  TRUSTEE_TYPE = "t"
+  VALID_TYPES = [AUTHORITY_TYPE, BULLETIN_BOARD_TYPE, VOTER_TYPE, TRUSTEE_TYPE]
+
+  /**
+   * Parses a message id string into a JS object.
+   *
+   * @param {String} messageId - A string with a message id.
+   * @returns {Object} - An object with the message id values.
+   */
+  static parse(messageId) {
+    [elements, author] = messageId.split("+")
+    [authority, electionId, type, subtype] = split(".", 4)
+    [authorType, authorId] = author.split(".", 2)
+
+    if (!VALID_TYPES.includes(authorType))
+    {
+      throw new Error("Invalid message identifier format");
+    }
+
+    return {
+      electionId: `${authority}.${electionId}`,
+      type,
+      subtype,
+      type_subtype: `${type}.${subtype}`,
+      author: {
+        type: authorType,
+        id: authorId
+      }
+    }
+  }
+
+  static format(electionId, type_subtype, authorType, authorId){
+    return `${electionId}.${type_subtype}+${authorType}.${authorId}`
+  }
+}

--- a/decidim-bulletin_board-js/src/client/message-identifier.js
+++ b/decidim-bulletin_board-js/src/client/message-identifier.js
@@ -32,7 +32,7 @@ export class MessageIdentifier {
       electionId: `${authority}.${electionId}`,
       type,
       subtype,
-      type_subtype: `${type}.${subtype}`,
+      typeSubtype: `${type}.${subtype}`,
       author: {
         type: authorType,
         id: authorId,

--- a/decidim-bulletin_board-js/src/key-ceremony/key-ceremony.js
+++ b/decidim-bulletin_board-js/src/key-ceremony/key-ceremony.js
@@ -5,7 +5,7 @@ export const WAIT_TIME_MS = 1_000; // 1s
 export const MESSAGE_RECEIVED = "[Message] Received";
 export const MESSAGE_PROCESSED = "[Message] Processed";
 
-const DEFAULT_STATE = { message: null, done: false };
+const DEFAULT_STATE = { message: null, done: false, save: false };
 
 /**
  * Handles all the key ceremony steps for a specific election and trustee.
@@ -157,7 +157,7 @@ export class KeyCeremony {
     });
 
     return this.bulletinBoardClient.processKeyCeremonyStep({
-      message_id: message.message_id,
+      messageId: message.message_id,
       signedData,
     });
   }

--- a/decidim-bulletin_board-js/src/key-ceremony/key-ceremony.js
+++ b/decidim-bulletin_board-js/src/key-ceremony/key-ceremony.js
@@ -151,21 +151,13 @@ export class KeyCeremony {
    * @throws An exception is raised if there is a problem with the client.
    */
   async sendMessageToBulletinBoard({ message }) {
-    const {
-      id: electionUniqueId,
-      currentTrusteeContext,
-    } = this.electionContext;
-
-    const { id: trusteeId } = currentTrusteeContext;
-    const messageId = `${electionUniqueId}.key_ceremony+t.${trusteeId}`;
-
     const signedData = await this.currentTrustee.sign({
+      iat: Math.round(+new Date() / 1000),
       ...message,
-      message_id: messageId,
     });
 
     return this.bulletinBoardClient.processKeyCeremonyStep({
-      messageId,
+      message_id: message.message_id,
       signedData,
     });
   }

--- a/decidim-bulletin_board-js/src/key-ceremony/key-ceremony.js
+++ b/decidim-bulletin_board-js/src/key-ceremony/key-ceremony.js
@@ -83,7 +83,9 @@ export class KeyCeremony {
   async processNextStep({ message, done }) {
     if (!done) {
       return this.waitForNextLogEntryResult().then(async (result) => {
-        await this.sendMessageToBulletinBoard(result);
+        if (result.message) {
+          await this.sendMessageToBulletinBoard(result);
+        }
         return this.processNextStep(result);
       });
     }

--- a/decidim-bulletin_board-js/src/key-ceremony/key-ceremony.test.js
+++ b/decidim-bulletin_board-js/src/key-ceremony/key-ceremony.test.js
@@ -94,11 +94,12 @@ describe("KeyCeremony", () => {
       });
       const result = await keyCeremony.run();
       expect(bulletinBoardClient.processKeyCeremonyStep).toHaveBeenCalledWith({
-        messageId: "election-1.key_ceremony+t.trustee-1",
+        messageId: "dummy.done",
         signedData: "1234",
       });
       expect(result).toEqual({
-        signedData: "1234",
+        message_id: "dummy.done",
+        content: "1234",
       });
     });
 
@@ -113,15 +114,16 @@ describe("KeyCeremony", () => {
       });
       const result = await keyCeremony.run();
       expect(bulletinBoardClient.processKeyCeremonyStep).toHaveBeenCalledWith({
-        messageId: "election-1.key_ceremony+t.trustee-1",
+        messageId: "dummy.step",
         signedData: "1234",
       });
       expect(bulletinBoardClient.processKeyCeremonyStep).toHaveBeenCalledWith({
-        messageId: "election-1.key_ceremony+t.trustee-1",
+        messageId: "dummy.done",
         signedData: "5678",
       });
       expect(result).toEqual({
-        signedData: "5678",
+        message_id: "dummy.done",
+        content: "5678",
       });
     });
 
@@ -138,10 +140,12 @@ describe("KeyCeremony", () => {
       expect(
         bulletinBoardClient.processKeyCeremonyStep
       ).not.toHaveBeenCalledWith({
-        signedData: "1234",
+        message_id: "dummy.done",
+        content: "1234",
       });
       expect(result).toEqual({
-        signedData: "5678",
+        message_id: "dummy.done",
+        content: "5678",
       });
     });
 
@@ -191,7 +195,13 @@ describe("KeyCeremony", () => {
           messageId: "dummy.done",
           signedData: "5678",
         },
-        result: { done: true, message: { signedData: "5678" } },
+        result: {
+          done: true,
+          message: {
+            message_id: "dummy.done",
+            content: "5678",
+          },
+        },
       });
     });
   });

--- a/decidim-bulletin_board-js/src/trustee/__mocks__/trustee.js
+++ b/decidim-bulletin_board-js/src/trustee/__mocks__/trustee.js
@@ -8,7 +8,8 @@ export class Trustee {
         return {
           done: false,
           message: {
-            signedData,
+            message_id: messageId,
+            content: signedData,
           },
         };
       }
@@ -16,14 +17,15 @@ export class Trustee {
         return {
           done: true,
           message: {
-            signedData,
+            message_id: messageId,
+            content: signedData,
           },
         };
       }
     }
   }
 
-  sign({ signedData }) {
-    return signedData;
+  sign({ content }) {
+    return content;
   }
 }

--- a/decidim-bulletin_board-js/src/trustee/trustee_wrapper_dummy.js
+++ b/decidim-bulletin_board-js/src/trustee/trustee_wrapper_dummy.js
@@ -1,6 +1,8 @@
 export const CREATE_ELECTION = "create_election";
-export const KEY_CEREMONY = "key_ceremony";
-export const JOINT_ELECTION_KEY = "joint_election_key";
+export const KEY_CEREMONY_STEP_1 = "key_ceremony.step_1";
+export const KEY_CEREMONY_JOINT_ELECTION_KEY = "key_ceremony.joint_election_key";
+
+import { MessageIdentifier } from "../client/message-identifier";
 
 /**
  * This is just a dummy implementation of a possible `TrusteeWrapper`.
@@ -9,57 +11,72 @@ export const JOINT_ELECTION_KEY = "joint_election_key";
 export class TrusteeWrapper {
   constructor({ trusteeId }) {
     this.trusteeId = trusteeId;
-    this.status = CREATE_ELECTION;
     this.electionId = null;
+    this.status = CREATE_ELECTION;
     this.electionTrusteesCount = 0;
     this.processedMessages = [];
   }
 
+  backup() {
+    return JSON.stringify(this)
+  }
+
+  static restore(state) {
+    return JSON.parse(state)
+  }
+
   processMessage(messageId, message) {
+    messageIdentifier = MessageIdentifier.parse(messageId);
     switch (this.status) {
       case CREATE_ELECTION: {
-        if (messageId.includes(CREATE_ELECTION)) {
-          this.status = KEY_CEREMONY;
-          this.electionId = message.election_id;
+        if (message_identifier.type === CREATE_ELECTION) {
+          this.status = KEY_CEREMONY_STEP_1;
+          this.electionId = messageIdentifier.electionId;
           this.processedMessages = [];
           this.electionTrusteesCount = message.trustees.length;
           return {
             done: false,
+            save: true,
             message: {
-              iat: Math.round(+new Date() / 1000),
-              type: this.status,
-              election_id: this.electionId,
-              election_public_key: 7,
-              owner_id: this.trusteeId,
+              message_id: MessageIdentifier.format(this.electionId, KEY_CEREMONY_STEP_1, MessageIdentifier.TRUSTEE, this.trusteeId),
+              content: JSON.stringify({
+                election_public_key: 7,
+                owner_id: this.trusteeId
+              })
             },
           };
         }
         break;
       }
-      case KEY_CEREMONY: {
+      case KEY_CEREMONY_STEP_1: {
         if (
-          messageId.includes(KEY_CEREMONY) &&
-          message.owner_id !== this.trusteeId
+          messageIdentifier.type_subtype ===
+          KEY_CEREMONY_STEP_1
         ) {
           this.processedMessages = [...this.processedMessages, message];
           if (
             this.processedMessages.length ===
-            this.electionTrusteesCount - 1
+            this.electionTrusteesCount
           ) {
-            this.status = JOINT_ELECTION_KEY;
+            this.status = KEY_CEREMONY_JOINT_ELECTION_KEY;
             return {
               done: false,
-              message: {},
+              save: false,
+              message: null,
             };
           }
         }
         break;
       }
-      case JOINT_ELECTION_KEY: {
-        if (messageId.includes(JOINT_ELECTION_KEY)) {
+      case KEY_CEREMONY_JOINT_ELECTION_KEY: {
+        if (
+          messageIdentifier.type_subtype ===
+          KEY_CEREMONY_JOINT_ELECTION_KEY
+        ) {
           return {
             done: true,
-            message,
+            save: false,
+            message: null,
           };
         }
         break;

--- a/decidim-bulletin_board-js/src/trustee/trustee_wrapper_dummy.js
+++ b/decidim-bulletin_board-js/src/trustee/trustee_wrapper_dummy.js
@@ -1,8 +1,9 @@
+import { MessageIdentifier, TRUSTEE_TYPE } from "../client/message-identifier";
+
 export const CREATE_ELECTION = "create_election";
 export const KEY_CEREMONY_STEP_1 = "key_ceremony.step_1";
-export const KEY_CEREMONY_JOINT_ELECTION_KEY = "key_ceremony.joint_election_key";
-
-import { MessageIdentifier } from "../client/message-identifier";
+export const KEY_CEREMONY_JOINT_ELECTION_KEY =
+  "key_ceremony.joint_election_key";
 
 /**
  * This is just a dummy implementation of a possible `TrusteeWrapper`.
@@ -18,18 +19,18 @@ export class TrusteeWrapper {
   }
 
   backup() {
-    return JSON.stringify(this)
+    return JSON.stringify(this);
   }
 
   static restore(state) {
-    return JSON.parse(state)
+    return JSON.parse(state);
   }
 
   processMessage(messageId, message) {
-    messageIdentifier = MessageIdentifier.parse(messageId);
+    const messageIdentifier = MessageIdentifier.parse(messageId);
     switch (this.status) {
       case CREATE_ELECTION: {
-        if (message_identifier.type === CREATE_ELECTION) {
+        if (messageIdentifier.type === CREATE_ELECTION) {
           this.status = KEY_CEREMONY_STEP_1;
           this.electionId = messageIdentifier.electionId;
           this.processedMessages = [];
@@ -38,26 +39,25 @@ export class TrusteeWrapper {
             done: false,
             save: true,
             message: {
-              message_id: MessageIdentifier.format(this.electionId, KEY_CEREMONY_STEP_1, MessageIdentifier.TRUSTEE, this.trusteeId),
+              message_id: MessageIdentifier.format(
+                this.electionId,
+                KEY_CEREMONY_STEP_1,
+                TRUSTEE_TYPE,
+                this.trusteeId
+              ),
               content: JSON.stringify({
                 election_public_key: 7,
-                owner_id: this.trusteeId
-              })
+                owner_id: this.trusteeId,
+              }),
             },
           };
         }
         break;
       }
       case KEY_CEREMONY_STEP_1: {
-        if (
-          messageIdentifier.type_subtype ===
-          KEY_CEREMONY_STEP_1
-        ) {
+        if (messageIdentifier.type_subtype === KEY_CEREMONY_STEP_1) {
           this.processedMessages = [...this.processedMessages, message];
-          if (
-            this.processedMessages.length ===
-            this.electionTrusteesCount
-          ) {
+          if (this.processedMessages.length === this.electionTrusteesCount) {
             this.status = KEY_CEREMONY_JOINT_ELECTION_KEY;
             return {
               done: false,
@@ -70,8 +70,7 @@ export class TrusteeWrapper {
       }
       case KEY_CEREMONY_JOINT_ELECTION_KEY: {
         if (
-          messageIdentifier.type_subtype ===
-          KEY_CEREMONY_JOINT_ELECTION_KEY
+          messageIdentifier.type_subtype === KEY_CEREMONY_JOINT_ELECTION_KEY
         ) {
           return {
             done: true,

--- a/decidim-bulletin_board-js/src/trustee/trustee_wrapper_dummy.js
+++ b/decidim-bulletin_board-js/src/trustee/trustee_wrapper_dummy.js
@@ -55,7 +55,7 @@ export class TrusteeWrapper {
         break;
       }
       case KEY_CEREMONY_STEP_1: {
-        if (messageIdentifier.type_subtype === KEY_CEREMONY_STEP_1) {
+        if (messageIdentifier.typeSubtype === KEY_CEREMONY_STEP_1) {
           this.processedMessages = [...this.processedMessages, message];
           if (this.processedMessages.length === this.electionTrusteesCount) {
             this.status = KEY_CEREMONY_JOINT_ELECTION_KEY;
@@ -69,9 +69,7 @@ export class TrusteeWrapper {
         break;
       }
       case KEY_CEREMONY_JOINT_ELECTION_KEY: {
-        if (
-          messageIdentifier.type_subtype === KEY_CEREMONY_JOINT_ELECTION_KEY
-        ) {
+        if (messageIdentifier.typeSubtype === KEY_CEREMONY_JOINT_ELECTION_KEY) {
           return {
             done: true,
             save: false,


### PR DESCRIPTION
While connecting the JS client with the BB we detected some inconsistencies in the messages format that needs to be addressed. So, we have defined a new message format, isolating the keys used by the BB and the information handled by the wrappers, like this:

```json
{
  "iat": 123456,
  "message_id": "decidim-barcelona.1.key_ceremony.trustee_election_keys+t.trustee-1",
  "content": "here goes the wrapper information"
}
```

This way, is possible to calculate the SHA for the content generated by the wrapper before completing and signing the message.

This PR apply the new format in the bulletin board application and also to the key ceremony part of the JS client.