### PR TITLE
Add a JS client method to get a LogEntry by hash

### DIFF
--- a/decidim-bulletin_board-js/src/client/__mocks__/graphql-client.js
+++ b/decidim-bulletin_board-js/src/client/__mocks__/graphql-client.js
@@ -7,9 +7,11 @@ const logEntriesByElection = {
         logEntries: [
           {
             signedData: "1234",
+            contentHash: "h1234",
           },
           {
             signedData: "5678",
+            contentHash: "h5678",
           },
         ],
       },
@@ -21,6 +23,7 @@ const logEntriesByElection = {
         logEntries: [
           {
             signedData: "9012",
+            contentHash: "h9012",
           },
         ],
       },
@@ -33,6 +36,16 @@ export class GraphQLClient {
     this.apiEndpointUrl = apiEndpointUrl;
     this.wsEndpointUrl = wsEndpointUrl;
     this.electionLogEntriesUpdates = new Subject();
+  }
+
+  getLogEntry({ electionUniqueId, contentHash }) {
+    return Promise.resolve(
+      logEntriesByElection[electionUniqueId].data.election.logEntries.find(
+        (logEntry) => {
+          return logEntry.contentHash === contentHash;
+        }
+      )
+    );
   }
 
   getElectionLogEntries({ electionUniqueId }) {

--- a/decidim-bulletin_board-js/src/client/client.js
+++ b/decidim-bulletin_board-js/src/client/client.js
@@ -15,6 +15,19 @@ export class Client {
   }
 
   /**
+   * Query a log entry for the given election unique id and the given content hash.
+   *
+   * @param {Object} params - An object that include the following options.
+   *  - {String} electionUniqueId - The election's unique id.
+   *  - {String} contentHash - The log entry content hash.
+   * @returns {Promise<Array<Object>>} - A log entry.
+   * @throws Will throw an error if the request is rejected.
+   */
+  getLogEntry({ electionUniqueId, contentHash }) {
+    return this.apiClient.getLogEntry({ electionUniqueId, contentHash });
+  }
+
+  /**
    * Query all log entries for the given election id.
    *
    * @param {Object} params - An object that include the following options.

--- a/decidim-bulletin_board-js/src/client/client.test.js
+++ b/decidim-bulletin_board-js/src/client/client.test.js
@@ -25,6 +25,19 @@ describe("Client", () => {
     expect(client.apiClient.wsEndpointUrl).toEqual(defaultParams.wsEndpointUrl);
   });
 
+  describe("getLogEntry", () => {
+    it("returns the log entry for the given hash", async () => {
+      const entry = await client.getLogEntry({
+        electionUniqueId: "election-1",
+        contentHash: "h1234",
+      });
+      expect(entry).toEqual({
+        signedData: "1234",
+        contentHash: "h1234",
+      });
+    });
+  });
+
   describe("getElectionLogEntries", () => {
     it("returns all the log entries from the corresponding election", async () => {
       const entries = await client.getElectionLogEntries({

--- a/decidim-bulletin_board-js/src/client/graphql-client.js
+++ b/decidim-bulletin_board-js/src/client/graphql-client.js
@@ -11,6 +11,7 @@ import ActionCable from "actioncable";
 import GET_ELECTION_LOG_ENTRIES from "./operations/get_election_log_entries";
 import SUBSCRIBE_TO_ELECTION_LOG from "./operations/subscribe_to_election_log";
 import PROCESS_KEY_CEREMONY_STEP from "./operations/process_key_ceremony_step";
+import GET_LOG_ENTRY from "./operations/get_log_entry";
 
 /**
  * This is the Bulletin Board API client that will use Apollo's client to
@@ -54,6 +55,27 @@ export class GraphQLClient {
       link: splitLink,
       cache: new InMemoryCache(),
     });
+  }
+
+  /**
+   * Query a log entry for the given election unique id and the given content hash.
+   *
+   * @param {Object} params - An object that include the following options.
+   *  - {String} electionUniqueId - The election's unique id.
+   *  - {String} contentHash - The log entry content hash.
+   * @returns {Promise<Array<Object>>} - A log entry.
+   * @throws Will throw an error if the request is rejected.
+   */
+  async getLogEntry({ electionUniqueId, contentHash }) {
+    const result = await this.apolloClient.query({
+      query: GET_LOG_ENTRY,
+      variables: {
+        electionUniqueId,
+        contentHash,
+      },
+    });
+
+    return result.data.logEntry;
   }
 
   /**

--- a/decidim-bulletin_board-js/src/client/graphql-client.test.js
+++ b/decidim-bulletin_board-js/src/client/graphql-client.test.js
@@ -18,6 +18,34 @@ describe("GraphQLClient", () => {
     });
   });
 
+  describe("getLogEntry", () => {
+    it("return the log entry given a election id and a content hash", async () => {
+      const logEntryResult = { messageId: "dummy.1", signedData: "1234" };
+
+      fetch.mockResponseOnce(
+        JSON.stringify({ data: { logEntry: logEntryResult } })
+      );
+
+      const logEntry = await client.getLogEntry({
+        electionUniqueId: "example.1",
+        contentHash: "1234",
+      });
+
+      expect(logEntry).toEqual(logEntryResult);
+    });
+
+    it("throws an error if something went wrong", async () => {
+      fetch.mockReject(() => Promise.reject(new Error("something went wrong")));
+
+      await expect(
+        client.getLogEntry({
+          electionUniqueId: "example.1",
+          contentHash: "1234",
+        })
+      ).rejects.toThrow("something went wrong");
+    });
+  });
+
   describe("getElectionLogEntries", () => {
     it("returns all the log entries given a election id", async () => {
       const logEntriesResult = [

--- a/decidim-bulletin_board-js/src/client/operations/get_log_entry.gql
+++ b/decidim-bulletin_board-js/src/client/operations/get_log_entry.gql
@@ -1,0 +1,9 @@
+query GetElectionLogEntries($electionUniqueId: String!, $contentHash: String!) {
+  logEntry(electionUniqueId: $electionUniqueId, contentHash: $contentHash) {
+    logEntry {
+      messageId
+      signedData
+      contentHash
+    }
+  }
+}

--- a/decidim-bulletin_board-js/src/client/operations/get_log_entry.gql
+++ b/decidim-bulletin_board-js/src/client/operations/get_log_entry.gql
@@ -1,9 +1,7 @@
 query GetElectionLogEntries($electionUniqueId: String!, $contentHash: String!) {
   logEntry(electionUniqueId: $electionUniqueId, contentHash: $contentHash) {
-    logEntry {
-      messageId
-      signedData
-      contentHash
-    }
+    messageId
+    signedData
+    contentHash
   }
 }


### PR DESCRIPTION
This PR adds a method to the JS client to use the endpoint implemented in #29 to retrieve a log entry using the hash of the log entry content.