### PR TITLE
Refactor bulletin board JS client

### DIFF
--- a/decidim-bulletin_board-js/src/client/message-identifier.js
+++ b/decidim-bulletin_board-js/src/client/message-identifier.js
@@ -23,6 +23,7 @@ export class MessageIdentifier {
     const [elements, author] = messageId.split("+");
     const [authority, electionId, type, subtype] = elements.split(".", 4);
     const [authorType, authorId] = author.split(".", 2);
+    const dotSubtype = subtype ? `.${subtype}` : "";
 
     if (!VALID_TYPES.includes(authorType)) {
       throw new Error("Invalid message identifier format");
@@ -32,7 +33,7 @@ export class MessageIdentifier {
       electionId: `${authority}.${electionId}`,
       type,
       subtype,
-      typeSubtype: `${type}.${subtype}`,
+      typeSubtype: `${type}${dotSubtype}`,
       author: {
         type: authorType,
         id: authorId,
@@ -44,3 +45,4 @@ export class MessageIdentifier {
     return `${electionId}.${typeSubtype}+${authorType}.${authorId}`;
   }
 }
+

--- a/decidim-bulletin_board-js/src/client/message-identifier.js
+++ b/decidim-bulletin_board-js/src/client/message-identifier.js
@@ -45,4 +45,3 @@ export class MessageIdentifier {
     return `${electionId}.${typeSubtype}+${authorType}.${authorId}`;
   }
 }
-

--- a/decidim-bulletin_board-js/src/index.js
+++ b/decidim-bulletin_board-js/src/index.js
@@ -1,5 +1,6 @@
 import { Client } from "./client/client";
 import { KeyCeremony } from "./key-ceremony/key-ceremony";
+import { MessageIdentifier } from "./client/message-identifier";
 import { Voter } from "./voter/voter";
 
-export { Client, KeyCeremony, Voter };
+export { Client, KeyCeremony, MessageIdentifier, Voter };

--- a/decidim-bulletin_board-js/src/key-ceremony/key-ceremony.js
+++ b/decidim-bulletin_board-js/src/key-ceremony/key-ceremony.js
@@ -61,6 +61,14 @@ export class KeyCeremony {
   }
 
   /**
+   * Returns the backup function of the TrusteeWrapper
+   * @returns {String}
+   */
+  backup() {
+    return this.currentTrustee.wrapper.backup()
+  }
+
+  /**
    * Starts or continues with the key ceremony.
    * @returns {Promise<Object>}
    */

--- a/decidim-bulletin_board-js/src/key-ceremony/key-ceremony.js
+++ b/decidim-bulletin_board-js/src/key-ceremony/key-ceremony.js
@@ -62,10 +62,10 @@ export class KeyCeremony {
 
   /**
    * Returns the backup function of the TrusteeWrapper
-   * @returns {String}
+   * @returns {string}
    */
   backup() {
-    return this.currentTrustee.wrapper.backup()
+    return this.currentTrustee.wrapper.backup();
   }
 
   /**


### PR DESCRIPTION
This PR exports the `MessageIdentifier` to be used in the `key_cermeony` process on Decidim. It also adds the `backup` method of the `TrusteeWrapper` to `KeyCeremony` to be used directly on Decidim calling the `key_ceremony`. 