### PR TITLE
Release version 0.5.1

### DIFF
--- a/decidim-bulletin_board-ruby/CHANGELOG.md
+++ b/decidim-bulletin_board-ruby/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2020-12-19
+
+### Fixed
+
+- Include the missing `close_ballot_box` method from the 0.4.0 release.
+- Fixes for the client methods
+
 ## [0.5.0] - 2020-12-19
 
 ### Changed
@@ -13,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Include the missing `open_ballot_box` and `close_ballot_box` methods from the previous release.
+- Include the missing `open_ballot_box` methods from the 0.4.0 release.
 - Added missing namespace on the seed task
 
 ## [0.4.0] - 2020-12-18

--- a/decidim-bulletin_board-ruby/Gemfile.lock
+++ b/decidim-bulletin_board-ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    decidim-bulletin_board (0.5.0)
+    decidim-bulletin_board (0.5.1)
       activemodel (>= 5.0.0)
       activesupport (>= 5.0.0)
       byebug (~> 11.0)
@@ -12,14 +12,14 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (6.0.3.4)
-      activesupport (= 6.0.3.4)
-    activesupport (6.0.3.4)
+    activemodel (6.1.0)
+      activesupport (= 6.1.0)
+    activesupport (6.1.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
-      zeitwerk (~> 2.2, >= 2.2.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.1)
@@ -88,9 +88,8 @@ GEM
       rubocop-ast (>= 0.7.1)
     ruby-progressbar (1.10.1)
     ruby2_keywords (0.0.2)
-    thread_safe (0.3.6)
-    tzinfo (1.2.9)
-      thread_safe (~> 0.1)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
     unicode-display_width (1.7.0)
     webmock (3.10.0)
       addressable (>= 2.3.6)

--- a/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/client.rb
+++ b/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/client.rb
@@ -44,10 +44,17 @@ module Decidim
       end
 
       def open_ballot_box(election_id)
-        open_ballot_box = Decidim::BulletinBoard::Election::OpenBallotBox.new(election_id)
+        open_ballot_box = Decidim::BulletinBoard::Authority::OpenBallotBox.new(election_id)
         open_ballot_box.on(:ok) { |election| return election }
         open_ballot_box.on(:error) { |error_message| raise StandardError, error_message }
         open_ballot_box.call
+      end
+
+      def close_ballot_box(election_id)
+        close_ballot_box = Decidim::BulletinBoard::Authority::CloseBallotBox.new(election_id)
+        close_ballot_box.on(:ok) { |election| return election }
+        close_ballot_box.on(:error) { |error_message| raise StandardError, error_message }
+        close_ballot_box.call
       end
 
       def cast_vote(election_id, voter_id, encrypted_vote)

--- a/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/version.rb
+++ b/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/version.rb
@@ -2,6 +2,6 @@
 
 module Decidim
   module BulletinBoard
-    VERSION = "0.5.0"
+    VERSION = "0.5.1"
   end
 end

--- a/decidim-bulletin_board-ruby/spec/decidim/bulletin_board/client_spec.rb
+++ b/decidim-bulletin_board-ruby/spec/decidim/bulletin_board/client_spec.rb
@@ -46,7 +46,7 @@ module Decidim
             stub_wisper_publisher("Decidim::BulletinBoard::Authority::OpenBallotBox", :call, :ok, double(status: "vote"))
           end
 
-          it "calls the OpenBallotBox command and return the new status" do
+          it "calls the OpenBallotBox command and returns the new status" do
             election = subject.open_ballot_box(election_id)
             expect(election.status).to eq("vote")
           end
@@ -71,7 +71,7 @@ module Decidim
             stub_wisper_publisher("Decidim::BulletinBoard::Authority::CloseBallotBox", :call, :ok, double(status: "tally"))
           end
 
-          it "calls the CloseBallotBox command and return the new status" do
+          it "calls the CloseBallotBox command and returns the new status" do
             election = subject.close_ballot_box(election_id)
             expect(election.status).to eq("tally")
           end

--- a/decidim-bulletin_board-ruby/spec/decidim/bulletin_board/client_spec.rb
+++ b/decidim-bulletin_board-ruby/spec/decidim/bulletin_board/client_spec.rb
@@ -38,15 +38,61 @@ module Decidim
         it { is_expected.not_to be_configured }
       end
 
+      describe "open_ballot_box" do
+        let(:election_id) { "test.1" }
+
+        context "when everything went ok" do
+          before do
+            stub_wisper_publisher("Decidim::BulletinBoard::Authority::OpenBallotBox", :call, :ok, double(status: "vote"))
+          end
+
+          it "calls the OpenBallotBox command and return the new status" do
+            election = subject.open_ballot_box(election_id)
+            expect(election.status).to eq("vote")
+          end
+        end
+
+        context "when something went wrong" do
+          before do
+            stub_wisper_publisher("Decidim::BulletinBoard::Authority::OpenBallotBox", :call, :error, "something went wrong")
+          end
+
+          it "calls the CastVote command and throws an error" do
+            expect { subject.open_ballot_box(election_id) }.to raise_error("something went wrong")
+          end
+        end
+      end
+
+      describe "close_ballot_box" do
+        let(:election_id) { "test.1" }
+
+        context "when everything went ok" do
+          before do
+            stub_wisper_publisher("Decidim::BulletinBoard::Authority::CloseBallotBox", :call, :ok, double(status: "tally"))
+          end
+
+          it "calls the CloseBallotBox command and return the new status" do
+            election = subject.close_ballot_box(election_id)
+            expect(election.status).to eq("tally")
+          end
+        end
+
+        context "when something went wrong" do
+          before do
+            stub_wisper_publisher("Decidim::BulletinBoard::Authority::CloseBallotBox", :call, :error, "something went wrong")
+          end
+
+          it "calls the CastVote command and throws an error" do
+            expect { subject.close_ballot_box(election_id) }.to raise_error("something went wrong")
+          end
+        end
+      end
+
       describe "cast_vote" do
-        let(:election_data) do
-          { election_id: "test.1" }
-        end
-        let(:voter_data) do
-          { voter_id: "voter.1" }
-        end
+        let(:election_id) { "test.1" }
+        let(:voter_id) { "voter.1" }
         let(:encrypted_vote) do
-          { question_1: "aNsWeR 1" }
+          { question_1: "aNsWeR 1" }.to_json
         end
 
         context "when everything went ok" do
@@ -55,7 +101,7 @@ module Decidim
           end
 
           it "calls the CastVote command and return the result" do
-            pending_message = subject.cast_vote(election_data, voter_data, encrypted_vote)
+            pending_message = subject.cast_vote(election_id, voter_id, encrypted_vote)
             expect(pending_message.status).to eq("enqueued")
           end
         end
@@ -66,7 +112,7 @@ module Decidim
           end
 
           it "calls the CastVote command and throws an error" do
-            expect { subject.cast_vote(election_data, voter_data, encrypted_vote) }.to raise_error("something went wrong")
+            expect { subject.cast_vote(election_id, voter_id, encrypted_vote) }.to raise_error("something went wrong")
           end
         end
       end


### PR DESCRIPTION
This PR fixes some errors of the 0.5.0 version and updates the changelog.
- Include the missing `close_ballot_box` method from the 0.4.0 release.
- Fixes for the client methods