### PR TITLE
Fix graphql schema file location

### DIFF
--- a/decidim-bulletin_board-ruby/Gemfile.lock
+++ b/decidim-bulletin_board-ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    decidim-bulletin_board (0.5.1)
+    decidim-bulletin_board (0.5.3)
       activemodel (>= 5.0.0)
       activesupport (>= 5.0.0)
       byebug (~> 11.0)

--- a/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/graphql/client.rb
+++ b/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/graphql/client.rb
@@ -7,7 +7,7 @@ module Decidim
       class Client
         def self.client
           @client ||= Graphlient::Client.new(BulletinBoard.server,
-                                             schema_path: "lib/decidim/bulletin_board/graphql/bb_schema.json",
+                                             schema_path: File.join(__dir__, "bb_schema.json"),
                                              headers: {
                                                "Authorization" => BulletinBoard.api_key
                                              })

--- a/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/version.rb
+++ b/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/version.rb
@@ -2,6 +2,6 @@
 
 module Decidim
   module BulletinBoard
-    VERSION = "0.5.2"
+    VERSION = "0.5.3"
   end
 end


### PR DESCRIPTION
When using the gem in the app, it doesn't load the schema right. This PR fixes that, using absolute paths for the json file path.