### PR TITLE
Fix notifier errors

### DIFF
--- a/decidim-bulletin_board-app/app/commands/concerns/log_entry_command.rb
+++ b/decidim-bulletin_board-app/app/commands/concerns/log_entry_command.rb
@@ -62,7 +62,7 @@ module LogEntryCommand
     end
 
     def process_message
-      @response_message = voting_scheme.process_message(message_identifier, log_entry.decoded_data)
+      @response_message = voting_scheme.process_message(message_identifier, log_entry.decoded_data.deep_dup)
       election.voting_scheme_state = voting_scheme.backup
       true
     rescue VotingScheme::RejectedMessage => e

--- a/decidim-bulletin_board-app/app/commands/enqueue_message.rb
+++ b/decidim-bulletin_board-app/app/commands/enqueue_message.rb
@@ -29,8 +29,9 @@ class EnqueueMessage < Rectify::Command
     transaction do
       create_pending_message!
       job.perform_later(pending_message.id)
-      broadcast(:ok, pending_message)
     end
+
+    broadcast(:ok, pending_message)
   end
 
   private

--- a/decidim-bulletin_board-app/app/commands/open_ballot_box.rb
+++ b/decidim-bulletin_board-app/app/commands/open_ballot_box.rb
@@ -32,7 +32,7 @@ class OpenBallotBox < Rectify::Command
         valid_author?(message_identifier.from_authority?) &&
         process_message
 
-      election.log_entries << log_entry
+      log_entry.election = election
       log_entry.save!
       election.status = :vote
       election.save!

--- a/decidim-bulletin_board-app/app/commands/process_key_ceremony_step.rb
+++ b/decidim-bulletin_board-app/app/commands/process_key_ceremony_step.rb
@@ -33,16 +33,13 @@ class ProcessKeyCeremonyStep < Rectify::Command
         valid_step?(election.key_ceremony?) &&
         process_message
 
-      election.log_entries << log_entry
+      log_entry.election = election
       log_entry.save!
       create_response_log_entry!
       election.save!
     end
 
-    LogEntryNotifier.new(log_entry).notify_subscribers
-    LogEntryNotifier.new(response_log_entry).notify_subscribers if response_log_entry.present?
-
-    broadcast(:ok)
+    broadcast(:ok, [log_entry, response_log_entry].compact)
   end
 
   private

--- a/decidim-bulletin_board-app/app/commands/vote.rb
+++ b/decidim-bulletin_board-app/app/commands/vote.rb
@@ -31,7 +31,7 @@ class Vote < Rectify::Command
       valid_step?(election.vote?) &&
       process_message
 
-    election.log_entries << log_entry
+    log_entry.election = election
     election.with_lock { log_entry.save! }
 
     broadcast(:ok)

--- a/decidim-bulletin_board-app/app/jobs/process_key_ceremony_step_job.rb
+++ b/decidim-bulletin_board-app/app/jobs/process_key_ceremony_step_job.rb
@@ -6,17 +6,28 @@ class ProcessKeyCeremonyStepJob < ApplicationJob
   def perform(pending_message_id)
     pending_message = PendingMessage.find(pending_message_id)
 
+    log_entries_to_notify = []
     pending_message.with_lock do
       next unless pending_message.enqueued?
 
       ProcessKeyCeremonyStep.call(pending_message.client, pending_message.message_id, pending_message.signed_data) do
-        on(:ok) { |_result| pending_message.status = :accepted }
-        on(:invalid) { |_result, _message| pending_message.status = :rejected }
+        on(:ok) do |log_entries|
+          log_entries_to_notify = log_entries
+          pending_message.status = :accepted
+        end
+        on(:invalid) do |message|
+          warn message
+          pending_message.status = :rejected
+        end
       end
 
       raise MessageNotProcessed unless pending_message.processed?
 
       pending_message.save!
+    end
+
+    log_entries_to_notify.each do |log_entry|
+      LogEntryNotifier.new(log_entry).notify_subscribers
     end
   end
 end


### PR DESCRIPTION
This PR tries to fix the errors raised when triggering events inside transaction, as sometimes the receiver code can't access to the rows created in the transaction until this is commited.