### PR TITLE
Add verify vote and get the vote process working

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,26 +1,27 @@
 {
-	"name": "Decidim Bulletin Board",
-	"dockerComposeFile": ["docker-compose.yml"],
-	"service": "rails",
-	"workspaceFolder": "/workspace",
+  "name": "Decidim Bulletin Board",
+  "dockerComposeFile": ["docker-compose.yml"],
+  "service": "rails",
+  "workspaceFolder": "/workspace",
 
-	// Set *default* container specific settings.json values on container create.
-	"settings": {
-		"terminal.integrated.shell.linux": "/bin/bash"
-	},
+  // Set *default* container specific settings.json values on container create.
+  "settings": {
+    "terminal.integrated.shell.linux": "/bin/bash"
+  },
 
-	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [
-		"rebornix.Ruby",
-		"donjayamanne.githistory"
-	],
+  // Add the IDs of extensions you want installed when the container is created.
+  "extensions": [
+    "rebornix.Ruby",
+    "donjayamanne.githistory",
+    "esbenp.prettier-vscode"
+  ],
 
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	"forwardPorts": [8000],
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  "forwardPorts": [8000],
 
-	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": ".devcontainer/post_create_command.sh",
+  // Use 'postCreateCommand' to run commands after the container is created.
+  "postCreateCommand": ".devcontainer/post_create_command.sh"
 
-	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
-	// "remoteUser": "vscode"
+  // Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
+  // "remoteUser": "vscode"
 }

--- a/decidim-bulletin_board-app/app/commands/concerns/log_entry_command.rb
+++ b/decidim-bulletin_board-app/app/commands/concerns/log_entry_command.rb
@@ -62,7 +62,7 @@ module LogEntryCommand
     end
 
     def process_message
-      @response_message = voting_scheme.process_message(message_identifier, log_entry.decoded_data)
+      @response_message = voting_scheme.process_message(message_identifier, log_entry.decoded_data.deep_dup)
       election.voting_scheme_state = voting_scheme.backup
       true
     rescue VotingScheme::RejectedMessage => e

--- a/decidim-bulletin_board-app/app/commands/enqueue_message.rb
+++ b/decidim-bulletin_board-app/app/commands/enqueue_message.rb
@@ -29,8 +29,9 @@ class EnqueueMessage < Rectify::Command
     transaction do
       create_pending_message!
       job.perform_later(pending_message.id)
-      broadcast(:ok, pending_message)
     end
+
+    broadcast(:ok, pending_message)
   end
 
   private

--- a/decidim-bulletin_board-app/app/commands/open_ballot_box.rb
+++ b/decidim-bulletin_board-app/app/commands/open_ballot_box.rb
@@ -32,7 +32,7 @@ class OpenBallotBox < Rectify::Command
         valid_author?(message_identifier.from_authority?) &&
         process_message
 
-      election.log_entries << log_entry
+      log_entry.election = election
       log_entry.save!
       election.status = :vote
       election.save!

--- a/decidim-bulletin_board-app/app/commands/process_key_ceremony_step.rb
+++ b/decidim-bulletin_board-app/app/commands/process_key_ceremony_step.rb
@@ -33,16 +33,13 @@ class ProcessKeyCeremonyStep < Rectify::Command
         valid_step?(election.key_ceremony?) &&
         process_message
 
-      election.log_entries << log_entry
+      log_entry.election = election
       log_entry.save!
       create_response_log_entry!
       election.save!
     end
 
-    LogEntryNotifier.new(log_entry).notify_subscribers
-    LogEntryNotifier.new(response_log_entry).notify_subscribers if response_log_entry.present?
-
-    broadcast(:ok)
+    broadcast(:ok, [log_entry, response_log_entry].compact)
   end
 
   private

--- a/decidim-bulletin_board-app/app/commands/vote.rb
+++ b/decidim-bulletin_board-app/app/commands/vote.rb
@@ -31,7 +31,7 @@ class Vote < Rectify::Command
       valid_step?(election.vote?) &&
       process_message
 
-    election.log_entries << log_entry
+    log_entry.election = election
     election.with_lock { log_entry.save! }
 
     broadcast(:ok)

--- a/decidim-bulletin_board-app/app/graphql/types/log_entry_type.rb
+++ b/decidim-bulletin_board-app/app/graphql/types/log_entry_type.rb
@@ -7,7 +7,7 @@ module Types
     field :client, Types::ClientType, null: false
     field :signed_data, String, null: false
     field :chained_hash, String, null: false
-    field :content_hash, String, null: false
+    field :content_hash, String, null: true
     field :message_id, String, null: false
   end
 end

--- a/decidim-bulletin_board-app/app/jobs/process_key_ceremony_step_job.rb
+++ b/decidim-bulletin_board-app/app/jobs/process_key_ceremony_step_job.rb
@@ -6,17 +6,28 @@ class ProcessKeyCeremonyStepJob < ApplicationJob
   def perform(pending_message_id)
     pending_message = PendingMessage.find(pending_message_id)
 
+    log_entries_to_notify = []
     pending_message.with_lock do
       next unless pending_message.enqueued?
 
       ProcessKeyCeremonyStep.call(pending_message.client, pending_message.message_id, pending_message.signed_data) do
-        on(:ok) { |_result| pending_message.status = :accepted }
-        on(:invalid) { |_result, _message| pending_message.status = :rejected }
+        on(:ok) do |log_entries|
+          log_entries_to_notify = log_entries
+          pending_message.status = :accepted
+        end
+        on(:invalid) do |message|
+          warn message
+          pending_message.status = :rejected
+        end
       end
 
       raise MessageNotProcessed unless pending_message.processed?
 
       pending_message.save!
+    end
+
+    log_entries_to_notify.each do |log_entry|
+      LogEntryNotifier.new(log_entry).notify_subscribers
     end
   end
 end

--- a/decidim-bulletin_board-app/app/jobs/vote_job.rb
+++ b/decidim-bulletin_board-app/app/jobs/vote_job.rb
@@ -10,8 +10,13 @@ class VoteJob < ApplicationJob
       next unless pending_message.enqueued?
 
       Vote.call(pending_message.client, pending_message.message_id, pending_message.signed_data) do
-        on(:ok) { |_result| pending_message.status = :accepted }
-        on(:invalid) { |_result, _message| pending_message.status = :rejected }
+        on(:ok) do
+          pending_message.status = :accepted
+        end
+        on(:invalid) do |message|
+          warn message
+          pending_message.status = :rejected
+        end
       end
 
       raise MessageNotProcessed unless pending_message.processed?

--- a/decidim-bulletin_board-js/src/key-ceremony/key-ceremony.js
+++ b/decidim-bulletin_board-js/src/key-ceremony/key-ceremony.js
@@ -213,7 +213,7 @@ export class KeyCeremony {
     }
 
     const signedData = await this.currentTrustee.sign({
-      iat: Math.round(+new Date() / 1000),
+      iat: (new Date() / 1000) | 0,
       ...message,
     });
 

--- a/decidim-bulletin_board-js/src/types.d.ts
+++ b/decidim-bulletin_board-js/src/types.d.ts
@@ -59,7 +59,7 @@ export type LogEntry = {
   __typename?: 'LogEntry';
   chainedHash: Scalars['String'];
   client: Client;
-  contentHash: Scalars['String'];
+  contentHash?: Maybe<Scalars['String']>;
   election: Election;
   id: Scalars['ID'];
   messageId: Scalars['String'];

--- a/decidim-bulletin_board-ruby/CHANGELOG.md
+++ b/decidim-bulletin_board-ruby/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+## [0.5.3] - 2020-12-20
+
+### Fixed
+
+- Fix the schema definition folder when used inside an app
+
 ## [0.5.2] - 2020-12-20
 
 ### Fixed

--- a/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/client.rb
+++ b/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/client.rb
@@ -17,6 +17,7 @@ module Decidim
       end
 
       attr_reader :server, :scheme, :api_key, :number_of_trustees, :authority_name
+
       delegate :authority_slug, to: Decidim::BulletinBoard::Command
 
       def quorum

--- a/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/client.rb
+++ b/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/client.rb
@@ -17,15 +17,12 @@ module Decidim
       end
 
       attr_reader :server, :scheme, :api_key, :number_of_trustees, :authority_name
+      delegate :authority_slug, to: Decidim::BulletinBoard::Command
 
       def quorum
         return 0 if @scheme.dig(:parameters, :quorum).blank?
 
         @scheme.dig(:parameters, :quorum)
-      end
-
-      def authority_slug
-        @authority_slug ||= authority_name.parameterize
       end
 
       def public_key

--- a/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/graphql/bb_schema.json
+++ b/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/graphql/bb_schema.json
@@ -434,13 +434,9 @@
 
               ],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null


### PR DESCRIPTION
This PR adds the verify vote method to the voter client. 

Also, it allows the contentHash to be null on the GraphQL types, to support returning the messages without a `content` key. 

Finally, it updates the changelog, includes the prettier extension in the dev containers and updates the changelog with some missing changes.