### PR TITLE
Support for request only the last log entries of an election

### DIFF
--- a/decidim-bulletin_board-app/app/graphql/types/election_type.rb
+++ b/decidim-bulletin_board-app/app/graphql/types/election_type.rb
@@ -6,7 +6,18 @@ module Types
     field :title, String, null: false
     field :status, String, null: false
     field :authority, Types::ClientType, null: false
-    field :log_entries, [Types::LogEntryType], null: false, description: "Returns the list of log entries for this election in the bulletin board"
     field :trustees, [Types::ClientType], null: false, description: "Returns the list of trustees for this election"
+
+    field :log_entries, [Types::LogEntryType], null: false, description: "Returns the list of log entries for this election in the bulletin board" do
+      argument :after, String, required: false
+
+      def resolve(parent, args, _context)
+        if args[:after]
+          parent.object.log_entries.where("id > ?", args[:after].to_i)
+        else
+          parent.object.log_entries
+        end
+      end
+    end
   end
 end

--- a/decidim-bulletin_board-app/app/graphql/types/log_entry_type.rb
+++ b/decidim-bulletin_board-app/app/graphql/types/log_entry_type.rb
@@ -2,7 +2,7 @@
 
 module Types
   class LogEntryType < Types::BaseObject
-    field :id, ID, null: false, method: :message_id
+    field :id, ID, null: false
     field :election, Types::ElectionType, null: false
     field :client, Types::ClientType, null: false
     field :signed_data, String, null: false

--- a/decidim-bulletin_board-app/config/environments/development.rb
+++ b/decidim-bulletin_board-app/config/environments/development.rb
@@ -60,4 +60,7 @@ Rails.application.configure do
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
+
+  # Allow accessing with .lvh.me URLs
+  config.hosts << /[a-z0-9-]+\.lvh\.me/
 end


### PR DESCRIPTION
This PR allow JS client to request only the last log entries of an election, allowing to use polling instead of GraphQL subscriptions.