### PR TITLE
refactor(js): add Election class and refactor key ceremony

### DIFF
--- a/decidim-bulletin_board-js/src/client/graphql-client.js
+++ b/decidim-bulletin_board-js/src/client/graphql-client.js
@@ -78,6 +78,7 @@ export class GraphQLClient {
    * Process a key ceremony step sending a signed message.
    *
    * @param {Object} params - An object that include the following options.
+   *  - {String} messageId - The message id.
    *  - {String} signedData - The signed data to be processed.
    * @returns {Promise<Object>} - A pending message created.
    * @throws Will throw an error if the request is rejected or the data contains an error.
@@ -86,8 +87,8 @@ export class GraphQLClient {
     const result = await this.apolloClient.mutate({
       mutation: PROCESS_KEY_CEREMONY_STEP,
       variables: {
-        signedData,
         messageId,
+        signedData,
       },
     });
 

--- a/decidim-bulletin_board-js/src/election/election.js
+++ b/decidim-bulletin_board-js/src/election/election.js
@@ -3,7 +3,7 @@ import { MessageIdentifier, TRUSTEE_TYPE } from "../client/message-identifier";
 export const WAIT_TIME_MS = 1_000; // 1s
 
 /**
- * Handles the election state and include some methods to interact with the election log.
+ * Handles the election state and includes some methods to interact with the election log.
  */
 export class Election {
   /**

--- a/decidim-bulletin_board-js/src/election/election.js
+++ b/decidim-bulletin_board-js/src/election/election.js
@@ -1,0 +1,96 @@
+import { MessageIdentifier, TRUSTEE_TYPE } from "../client/message-identifier";
+
+export const WAIT_TIME_MS = 1_000; // 1s
+
+/**
+ * Handles the election state and include some methods to interact with the election log.
+ */
+export class Election {
+  /**
+   * Initializes the class with the given params.
+   *
+   * @constructor
+   * @param {Object} params - An object that contains the initialization params.
+   *  - {Client} bulletinBoardClient - An instance of the Bulletin Board Client
+   *  - {String} uniqueId - The unique identifier of an election.
+   *  - {Object?} options - An optional object with some extra options.
+   */
+  constructor({ bulletinBoardClient, uniqueId, options }) {
+    this.uniqueId = uniqueId;
+    this.bulletinBoardClient = bulletinBoardClient;
+    this.logEntries = [];
+    this.subscriptionId = null;
+    this.options = options || { waitUntilNextCheck: WAIT_TIME_MS };
+  }
+
+  /**
+   * Store the election log entries and periodically check if there are new entries.
+   *
+   * @returns {undefined}
+   */
+  subscribeToLogEntriesChanges() {
+    this.unsubscribeToLogEntriesChanges();
+
+    this.getLogEntries();
+
+    this.subscriptionId = setInterval(() => {
+      this.getLogEntries();
+    }, this.options.waitUntilNextCheck);
+  }
+
+  /**
+   * Clear the periodically checks of new log entries.
+   *
+   * @returns {undefined}
+   */
+  unsubscribeToLogEntriesChanges() {
+    if (this.subscriptionId !== null) {
+      clearInterval(this.subscriptionId);
+      this.subscriptionId = null;
+    }
+  }
+
+  /**
+   * Return the last message stored in the log sent by the given trustee.
+   *
+   * @param {String} trusteeId - The unique identifier of a trustee.
+   * @returns {Object|null}
+   */
+  getLastMessageFromTrustee(trusteeId) {
+    for (let i = this.logEntries.length - 1; i >= 0; i--) {
+      const logEntry = this.logEntries[i];
+      const messageIdentifier = MessageIdentifier.parse(logEntry.messageId);
+      if (
+        messageIdentifier.author.type === TRUSTEE_TYPE &&
+        messageIdentifier.author.id === trusteeId
+      ) {
+        return logEntry;
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Uses the bulletin board client to get all the election log entries after the
+   * last log entry stored in the election's state.
+   *
+   * @private
+   * @returns {nothing}
+   */
+  getLogEntries() {
+    const lastLogEntry = this.logEntries[this.logEntries.length - 1];
+    const after = (lastLogEntry && lastLogEntry.id) || null;
+
+    this.bulletinBoardClient
+      .getElectionLogEntries({
+        electionUniqueId: this.uniqueId,
+        after,
+      })
+      .then((logEntries) => {
+        if (logEntries.length) {
+          this.logEntries = [...this.logEntries, ...logEntries];
+        }
+      });
+  }
+}

--- a/decidim-bulletin_board-js/src/election/election.test.js
+++ b/decidim-bulletin_board-js/src/election/election.test.js
@@ -30,7 +30,7 @@ describe("Election", () => {
     jest.clearAllMocks();
   });
 
-  it("initialize the election with the correct params", () => {
+  it("initializes the election with the correct params", () => {
     expect(election.bulletinBoardClient).toEqual(
       defaultParams.bulletinBoardClient
     );
@@ -46,7 +46,7 @@ describe("Election", () => {
     });
 
     describe("when the time has not passed", () => {
-      it("get the last log entries from the bulletin board", () => {
+      it("gets the last log entries from the bulletin board", () => {
         expect(bulletinBoardClient.getElectionLogEntries).toHaveBeenCalledWith({
           electionUniqueId: defaultParams.uniqueId,
           after: null,
@@ -63,7 +63,7 @@ describe("Election", () => {
         jest.advanceTimersByTime(WAIT_TIME_MS);
       });
 
-      it("get the last log entries from the bulletin board", () => {
+      it("gets the last log entries from the bulletin board", () => {
         expect(bulletinBoardClient.getElectionLogEntries).toHaveBeenCalledWith({
           electionUniqueId: defaultParams.uniqueId,
           after: null,
@@ -79,7 +79,7 @@ describe("Election", () => {
       jest.clearAllMocks();
     });
 
-    it("clear the interval so stops the log entries subscription", () => {
+    it("clears the interval so stops the log entries subscription", () => {
       election.unsubscribeToLogEntriesChanges();
       jest.advanceTimersByTime(WAIT_TIME_MS);
       expect(bulletinBoardClient.getElectionLogEntries).not.toHaveBeenCalled();

--- a/decidim-bulletin_board-js/src/election/election.test.js
+++ b/decidim-bulletin_board-js/src/election/election.test.js
@@ -1,0 +1,144 @@
+import { Election, WAIT_TIME_MS } from "./election";
+import { MessageIdentifier, TRUSTEE_TYPE } from "../client/message-identifier";
+
+describe("Election", () => {
+  const bulletinBoardClient = {
+    getElectionLogEntries: () => jest.fn(),
+  };
+
+  const defaultParams = {
+    uniqueId: "1",
+    bulletinBoardClient,
+  };
+
+  const buildElection = (params = defaultParams) => {
+    return new Election(params);
+  };
+
+  let election;
+
+  beforeEach(async () => {
+    jest.useFakeTimers();
+    election = buildElection();
+    jest
+      .spyOn(bulletinBoardClient, "getElectionLogEntries")
+      .mockImplementation(() => Promise.resolve([2]));
+  });
+
+  afterEach(() => {
+    election.unsubscribeToLogEntriesChanges();
+    jest.clearAllMocks();
+  });
+
+  it("initialize the election with the correct params", () => {
+    expect(election.bulletinBoardClient).toEqual(
+      defaultParams.bulletinBoardClient
+    );
+    expect(election.uniqueId).toEqual(defaultParams.uniqueId);
+    expect(election.logEntries).toEqual([]);
+    expect(election.subscriptionId).toBeNull();
+  });
+
+  describe("subscribeToLogEntriesChanges", () => {
+    beforeEach(async () => {
+      election.logEntries = [1];
+      election.subscribeToLogEntriesChanges();
+    });
+
+    describe("when the time has not passed", () => {
+      it("get the last log entries from the bulletin board", () => {
+        expect(bulletinBoardClient.getElectionLogEntries).toHaveBeenCalledWith({
+          electionUniqueId: defaultParams.uniqueId,
+          after: null,
+        });
+        expect(election.logEntries).toEqual([1, 2]);
+      });
+    });
+
+    describe("when the time has passed", () => {
+      beforeEach(async () => {
+        jest
+          .spyOn(bulletinBoardClient, "getElectionLogEntries")
+          .mockImplementation(() => Promise.resolve([3]));
+        jest.advanceTimersByTime(WAIT_TIME_MS);
+      });
+
+      it("get the last log entries from the bulletin board", () => {
+        expect(bulletinBoardClient.getElectionLogEntries).toHaveBeenCalledWith({
+          electionUniqueId: defaultParams.uniqueId,
+          after: null,
+        });
+        expect(election.logEntries).toEqual([1, 2, 3]);
+      });
+    });
+  });
+
+  describe("unsubscribeToLogEntriesChanges", () => {
+    beforeEach(async () => {
+      election.subscribeToLogEntriesChanges();
+      jest.clearAllMocks();
+    });
+
+    it("clear the interval so stops the log entries subscription", () => {
+      election.unsubscribeToLogEntriesChanges();
+      jest.advanceTimersByTime(WAIT_TIME_MS);
+      expect(bulletinBoardClient.getElectionLogEntries).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("getLastMessageFromTrustee", () => {
+    const trusteeId = "some-trustee";
+
+    describe("when there are no messages from the trustee", () => {
+      beforeEach(() => {
+        election.logEntries = [
+          {
+            messageId: MessageIdentifier.format(
+              election.uniqueId,
+              "some-subtype",
+              TRUSTEE_TYPE,
+              "some-other-trustee"
+            ),
+            signedData: "5678",
+          },
+        ];
+      });
+
+      it("returns null", () => {
+        expect(election.getLastMessageFromTrustee(trusteeId)).toEqual(null);
+      });
+    });
+
+    describe("when there are messages from the trustee", () => {
+      beforeEach(() => {
+        election.logEntries = [
+          {
+            messageId: MessageIdentifier.format(
+              election.uniqueId,
+              "some-subtype",
+              TRUSTEE_TYPE,
+              trusteeId
+            ),
+            signedData: "1234",
+          },
+          {
+            messageId: MessageIdentifier.format(
+              election.uniqueId,
+              "some-subtype",
+              TRUSTEE_TYPE,
+              trusteeId
+            ),
+            signedData: "5678",
+          },
+        ];
+      });
+
+      it("returns the last message send by the trustee", () => {
+        expect(election.getLastMessageFromTrustee(trusteeId)).toEqual({
+          messageId: "1.some-subtype+t.some-trustee",
+          signedData: "5678",
+        });
+      });
+    });
+  });
+});

--- a/decidim-bulletin_board-js/src/index.js
+++ b/decidim-bulletin_board-js/src/index.js
@@ -1,6 +1,8 @@
 import { Client } from "./client/client";
+import { Election } from "./election/election";
+import { Trustee } from "./trustee/trustee";
 import { KeyCeremony } from "./key-ceremony/key-ceremony";
 import { MessageIdentifier } from "./client/message-identifier";
 import { Voter } from "./voter/voter";
 
-export { Client, KeyCeremony, MessageIdentifier, Voter };
+export { Client, Election, Trustee, KeyCeremony, MessageIdentifier, Voter };

--- a/decidim-bulletin_board-js/src/key-ceremony/key-ceremony.js
+++ b/decidim-bulletin_board-js/src/key-ceremony/key-ceremony.js
@@ -35,10 +35,10 @@ export class KeyCeremony {
    *
    * Initializes a subscription to store new log entries for the given election.
    *
-   * @returns {undefined}
+   * @returns {Promise<undefined>}
    */
   setup() {
-    this.election.subscribeToLogEntriesChanges();
+    return this.election.subscribeToLogEntriesChanges();
   }
 
   /**

--- a/decidim-bulletin_board-js/src/key-ceremony/key-ceremony.test.js
+++ b/decidim-bulletin_board-js/src/key-ceremony/key-ceremony.test.js
@@ -3,38 +3,31 @@ import {
   MESSAGE_RECEIVED,
   MESSAGE_PROCESSED,
 } from "./key-ceremony";
+import { Trustee } from "../trustee/trustee";
 
 import { buildMessageId } from "../test-utils";
 
 jest.mock("../trustee/trustee");
 
 describe("KeyCeremony", () => {
-  const electionLogEntriesUpdates = [];
+  const election = {
+    subscribeToLogEntriesChanges: jest.fn(),
+    unsubscribeToLogEntriesChanges: jest.fn(),
+    logEntries: [],
+  };
 
   const bulletinBoardClient = {
-    getElectionLogEntries: jest.fn(() => {
-      const result = [...electionLogEntriesUpdates];
-      electionLogEntriesUpdates.length = 0;
-      return Promise.resolve(result);
-    }),
     processKeyCeremonyStep: jest.fn((logEntry) => {
-      electionLogEntriesUpdates.push(logEntry);
+      election.logEntries = [...election.logEntries, logEntry];
     }),
   };
 
-  const currentTrusteeContext = {
-    id: "trustee-1",
-    identificationKeys: {},
-  };
-
-  const electionContext = {
-    id: "election-1",
-    currentTrusteeContext,
-  };
+  const trustee = new Trustee();
 
   const defaultParams = {
     bulletinBoardClient,
-    electionContext,
+    election,
+    trustee,
     options: {
       bulletinBoardWaitTime: 0,
     },
@@ -54,228 +47,280 @@ describe("KeyCeremony", () => {
     expect(keyCeremony.bulletinBoardClient).toEqual(
       defaultParams.bulletinBoardClient
     );
-    expect(keyCeremony.electionContext).toEqual(defaultParams.electionContext);
+    expect(keyCeremony.election).toEqual(defaultParams.election);
+    expect(keyCeremony.trustee).toEqual(defaultParams.trustee);
     expect(keyCeremony.options).toEqual(defaultParams.options);
+    expect(keyCeremony.response).toBeNull();
+    expect(keyCeremony.nextLogEntryIndexToProcess).toEqual(0);
   });
 
   describe("setup", () => {
-    beforeEach(async () => {
-      electionLogEntriesUpdates.push({ messageId: "foo", signedData: "5678" });
-      await keyCeremony.setup();
+    beforeEach(() => {
+      keyCeremony.setup();
     });
 
-    it("query the first log entries for the given election context", () => {
-      expect(bulletinBoardClient.getElectionLogEntries).toHaveBeenCalledWith({
-        electionUniqueId: electionContext.id,
-        after: null,
-      });
-      expect(keyCeremony.electionLogEntries.length).toEqual(1);
+    it("uses the election object to subscribe to log entries changes", () => {
+      expect(election.subscribeToLogEntriesChanges).toHaveBeenCalled();
+    });
+  });
+
+  describe("tearDown", () => {
+    beforeEach(() => {
+      keyCeremony.tearDown();
+    });
+
+    it("uses the election object to subscribe to log entries changes", () => {
+      expect(election.unsubscribeToLogEntriesChanges).toHaveBeenCalled();
     });
   });
 
   describe("run", () => {
-    beforeEach(async () => {
-      await keyCeremony.setup();
+    beforeEach(() => {
+      keyCeremony.setup();
+      jest.spyOn(keyCeremony, "tearDown");
     });
 
-    it("processes messages until a save message, sending them in the next run call", async () => {
-      electionLogEntriesUpdates.push({
-        messageId: buildMessageId("dummy.send"),
-        signedData: "1234",
-      });
-      electionLogEntriesUpdates.push({
-        messageId: buildMessageId("dummy.save"),
-        signedData: "5678",
-      });
-      electionLogEntriesUpdates.push({
-        messageId: buildMessageId("dummy.done"),
-        signedData: "0912",
-      });
-      await keyCeremony.run();
-      expect(bulletinBoardClient.processKeyCeremonyStep).toHaveBeenCalledWith({
-        messageId: buildMessageId("dummy.response_send"),
-        signedData: "1234",
-      });
-      expect(
-        bulletinBoardClient.processKeyCeremonyStep
-      ).not.toHaveBeenCalledWith({
-        messageId: buildMessageId("dummy.response_save"),
-        signedData: "5678",
-      });
-      await keyCeremony.run();
-      expect(bulletinBoardClient.processKeyCeremonyStep).toHaveBeenCalledWith({
-        messageId: buildMessageId("dummy.response_save"),
-        signedData: "5678",
-      });
-    });
-
-    it("processes messages until a done message", async () => {
-      electionLogEntriesUpdates.push({
-        messageId: buildMessageId("dummy.nothing"),
-        signedData: "1234",
-      });
-      electionLogEntriesUpdates.push({
-        messageId: buildMessageId("dummy.send"),
-        signedData: "5678",
-      });
-      electionLogEntriesUpdates.push({
-        messageId: buildMessageId("dummy.done"),
-        signedData: "9012",
-      });
-      electionLogEntriesUpdates.push({
-        messageId: buildMessageId("dummy.send"),
-        signedData: "1234",
-      });
-      await keyCeremony.run();
-      expect(bulletinBoardClient.processKeyCeremonyStep).toHaveBeenCalledWith({
-        messageId: buildMessageId("dummy.response_send"),
-        signedData: "5678",
-      });
-      expect(
-        bulletinBoardClient.processKeyCeremonyStep
-      ).not.toHaveBeenCalledWith({
-        messageId: buildMessageId("dummy.response_send"),
-        signedData: "1234",
-      });
-    });
-
-    it("skips the processed log entries that doesn't output a result", async () => {
-      electionLogEntriesUpdates.push({
-        messageId: buildMessageId("dummy.nothing"),
-        signedData: "1234",
-      });
-      electionLogEntriesUpdates.push({
-        messageId: buildMessageId("dummy.send"),
-        signedData: "5678",
-      });
-      electionLogEntriesUpdates.push({
-        messageId: buildMessageId("dummy.done"),
-        signedData: "9012",
-      });
-      await keyCeremony.run();
-      expect(
-        bulletinBoardClient.processKeyCeremonyStep
-      ).not.toHaveBeenCalledWith({
-        message_id: buildMessageId("dummy.nothing"),
-        content: "1234",
-      });
-      expect(
-        bulletinBoardClient.processKeyCeremonyStep
-      ).not.toHaveBeenCalledWith({
-        message_id: buildMessageId("dummy.response_send"),
-        content: "5678",
-      });
-    });
-
-    it("doesn't send a message already sent", async () => {
-      electionLogEntriesUpdates.push({
-        messageId: buildMessageId("dummy.send"),
-        signedData: "5678",
-      });
-      electionLogEntriesUpdates.push({
-        messageId: buildMessageId("dummy.save"),
-        signedData: "9012",
-      });
-      await keyCeremony.run();
-      expect(bulletinBoardClient.processKeyCeremonyStep).toHaveBeenCalledWith({
-        messageId: buildMessageId("dummy.response_send"),
-        signedData: "5678",
-      });
-      electionLogEntriesUpdates.push({
-        messageId: buildMessageId("dummy.send"),
-        signedData: "aaaa",
-      });
-      electionLogEntriesUpdates.push({
-        messageId: buildMessageId("dummy.done"),
-        signedData: "bbbb",
-      });
-      await keyCeremony.run();
-      expect(
-        bulletinBoardClient.processKeyCeremonyStep
-      ).not.toHaveBeenCalledWith({
-        messageId: buildMessageId("dummy.response_send"),
-        signedData: "aaaa",
-      });
-    });
-
-    it("reports all the events", async () => {
-      let events = [];
-
-      electionLogEntriesUpdates.push({
-        messageId: buildMessageId("dummy.nothing"),
-        signedData: "1234",
-      });
-      electionLogEntriesUpdates.push({
-        messageId: buildMessageId("dummy.send"),
-        signedData: "5678",
-      });
-      electionLogEntriesUpdates.push({
-        messageId: buildMessageId("dummy.done"),
-        signedData: "9012",
+    describe("when the trustee doesn't need to be restored", () => {
+      beforeEach(() => {
+        jest
+          .spyOn(trustee, "needsToBeRestored")
+          .mockImplementation(() => false);
       });
 
-      keyCeremony.events.subscribe((event) => {
-        events = [...events, event];
+      afterEach(() => {
+        expect(keyCeremony.tearDown).toHaveBeenCalled();
       });
 
-      await keyCeremony.run();
-
-      expect(events[0]).toEqual({
-        type: MESSAGE_RECEIVED,
-        message: {
-          messageId: buildMessageId("dummy.nothing"),
-          signedData: "1234",
-        },
-      });
-      expect(events[1]).toEqual({
-        type: MESSAGE_PROCESSED,
-        message: {
-          messageId: buildMessageId("dummy.nothing"),
-          signedData: "1234",
-        },
-        result: null,
-      });
-      expect(events[2]).toEqual({
-        type: MESSAGE_RECEIVED,
-        message: {
-          messageId: buildMessageId("dummy.send"),
-          signedData: "5678",
-        },
-      });
-      expect(events[3]).toEqual({
-        type: MESSAGE_PROCESSED,
-        message: {
-          messageId: buildMessageId("dummy.send"),
-          signedData: "5678",
-        },
-        result: {
-          done: false,
-          save: false,
-          message: {
-            message_id: buildMessageId("dummy.response_send"),
-            content: "5678",
+      it("processes messages until a save message, sending them in the next run call", async () => {
+        election.logEntries = [
+          {
+            messageId: buildMessageId("dummy.send"),
+            signedData: "1234",
           },
-        },
+          {
+            messageId: buildMessageId("dummy.save"),
+            signedData: "5678",
+          },
+          {
+            messageId: buildMessageId("dummy.done"),
+            signedData: "0912",
+          },
+        ];
+        await keyCeremony.run();
+        expect(bulletinBoardClient.processKeyCeremonyStep).toHaveBeenCalledWith(
+          {
+            messageId: buildMessageId("dummy.response_send"),
+            signedData: "1234",
+          }
+        );
+        expect(
+          bulletinBoardClient.processKeyCeremonyStep
+        ).not.toHaveBeenCalledWith({
+          messageId: buildMessageId("dummy.response_save"),
+          signedData: "5678",
+        });
+        await keyCeremony.run();
+        expect(bulletinBoardClient.processKeyCeremonyStep).toHaveBeenCalledWith(
+          {
+            messageId: buildMessageId("dummy.response_save"),
+            signedData: "5678",
+          }
+        );
       });
 
-      expect(events[4]).toEqual({
-        type: MESSAGE_RECEIVED,
-        message: {
-          messageId: buildMessageId("dummy.done"),
-          signedData: "9012",
-        },
+      it("processes messages until a done message", async () => {
+        election.logEntries = [
+          {
+            messageId: buildMessageId("dummy.nothing"),
+            signedData: "1234",
+          },
+          {
+            messageId: buildMessageId("dummy.send"),
+            signedData: "5678",
+          },
+          {
+            messageId: buildMessageId("dummy.done"),
+            signedData: "9012",
+          },
+          {
+            messageId: buildMessageId("dummy.send"),
+            signedData: "1234",
+          },
+        ];
+        await keyCeremony.run();
+        expect(bulletinBoardClient.processKeyCeremonyStep).toHaveBeenCalledWith(
+          {
+            messageId: buildMessageId("dummy.response_send"),
+            signedData: "5678",
+          }
+        );
+        expect(
+          bulletinBoardClient.processKeyCeremonyStep
+        ).not.toHaveBeenCalledWith({
+          messageId: buildMessageId("dummy.response_send"),
+          signedData: "1234",
+        });
       });
-      expect(events[5]).toEqual({
-        type: MESSAGE_PROCESSED,
-        message: {
-          messageId: buildMessageId("dummy.done"),
-          signedData: "9012",
-        },
-        result: {
-          save: false,
-          done: true,
-          message: null,
-        },
+
+      it("skips the processed log entries that doesn't output a result", async () => {
+        election.logEntries = [
+          {
+            messageId: buildMessageId("dummy.nothing"),
+            signedData: "1234",
+          },
+          {
+            messageId: buildMessageId("dummy.send"),
+            signedData: "5678",
+          },
+          {
+            messageId: buildMessageId("dummy.done"),
+            signedData: "9012",
+          },
+        ];
+        await keyCeremony.run();
+        expect(
+          bulletinBoardClient.processKeyCeremonyStep
+        ).not.toHaveBeenCalledWith({
+          message_id: buildMessageId("dummy.nothing"),
+          content: "1234",
+        });
+        expect(
+          bulletinBoardClient.processKeyCeremonyStep
+        ).not.toHaveBeenCalledWith({
+          message_id: buildMessageId("dummy.response_send"),
+          content: "5678",
+        });
+      });
+
+      it("doesn't send a message already sent", async () => {
+        election.logEntries = [
+          {
+            messageId: buildMessageId("dummy.send"),
+            signedData: "5678",
+          },
+          {
+            messageId: buildMessageId("dummy.save"),
+            signedData: "9012",
+          },
+        ];
+        await keyCeremony.run();
+        expect(bulletinBoardClient.processKeyCeremonyStep).toHaveBeenCalledWith(
+          {
+            messageId: buildMessageId("dummy.response_send"),
+            signedData: "5678",
+          }
+        );
+        election.logEntries = [
+          ...election.logEntries,
+          {
+            messageId: buildMessageId("dummy.send"),
+            signedData: "aaaa",
+          },
+          {
+            messageId: buildMessageId("dummy.done"),
+            signedData: "bbbb",
+          },
+        ];
+        await keyCeremony.run();
+        expect(
+          bulletinBoardClient.processKeyCeremonyStep
+        ).not.toHaveBeenCalledWith({
+          messageId: buildMessageId("dummy.response_send"),
+          signedData: "aaaa",
+        });
+      });
+
+      it("reports all the events", async () => {
+        let events = [];
+
+        election.logEntries = [
+          {
+            messageId: buildMessageId("dummy.nothing"),
+            signedData: "1234",
+          },
+          {
+            messageId: buildMessageId("dummy.send"),
+            signedData: "5678",
+          },
+          {
+            messageId: buildMessageId("dummy.done"),
+            signedData: "9012",
+          },
+        ];
+
+        keyCeremony.events.subscribe((event) => {
+          events = [...events, event];
+        });
+
+        await keyCeremony.run();
+
+        expect(events[0]).toEqual({
+          type: MESSAGE_RECEIVED,
+          message: {
+            messageId: buildMessageId("dummy.nothing"),
+            signedData: "1234",
+          },
+        });
+        expect(events[1]).toEqual({
+          type: MESSAGE_PROCESSED,
+          message: {
+            messageId: buildMessageId("dummy.nothing"),
+            signedData: "1234",
+          },
+          result: null,
+        });
+        expect(events[2]).toEqual({
+          type: MESSAGE_RECEIVED,
+          message: {
+            messageId: buildMessageId("dummy.send"),
+            signedData: "5678",
+          },
+        });
+        expect(events[3]).toEqual({
+          type: MESSAGE_PROCESSED,
+          message: {
+            messageId: buildMessageId("dummy.send"),
+            signedData: "5678",
+          },
+          result: {
+            done: false,
+            save: false,
+            message: {
+              message_id: buildMessageId("dummy.response_send"),
+              content: "5678",
+            },
+          },
+        });
+
+        expect(events[4]).toEqual({
+          type: MESSAGE_RECEIVED,
+          message: {
+            messageId: buildMessageId("dummy.done"),
+            signedData: "9012",
+          },
+        });
+        expect(events[5]).toEqual({
+          type: MESSAGE_PROCESSED,
+          message: {
+            messageId: buildMessageId("dummy.done"),
+            signedData: "9012",
+          },
+          result: {
+            save: false,
+            done: true,
+            message: null,
+          },
+        });
+      });
+    });
+
+    describe("when the trustee needs to be restored", () => {
+      beforeEach(() => {
+        jest.spyOn(trustee, "needsToBeRestored").mockImplementation(() => true);
+      });
+
+      it("throws an error", async () => {
+        await expect(keyCeremony.run()).rejects.toThrow();
       });
     });
   });

--- a/decidim-bulletin_board-js/src/trustee/__mocks__/trustee.js
+++ b/decidim-bulletin_board-js/src/trustee/__mocks__/trustee.js
@@ -41,7 +41,7 @@ export class Trustee {
     return content;
   }
 
-  checkRestoreNeeded(_messageId) {
-    return false;
+  needsToBeRestored() {
+    return true;
   }
 }

--- a/decidim-bulletin_board-js/src/trustee/__mocks__/trustee_wrapper_dummy.js
+++ b/decidim-bulletin_board-js/src/trustee/__mocks__/trustee_wrapper_dummy.js
@@ -4,4 +4,10 @@ export class TrusteeWrapper {
   }
 
   processMessage() {}
+
+  needsToBeRestored() {}
+
+  backup() {}
+
+  restore() {}
 }

--- a/decidim-bulletin_board-js/src/trustee/trustee_wrapper_dummy.js
+++ b/decidim-bulletin_board-js/src/trustee/trustee_wrapper_dummy.js
@@ -10,6 +10,13 @@ export const KEY_CEREMONY_JOINT_ELECTION_KEY =
  * It is based on the dummy voting schema that we are using in the Bulletin Board.
  */
 export class TrusteeWrapper {
+  /**
+   * Initializes the class with the given params.
+   *
+   * @constructor
+   * @param {Object} params - An object that contains the initialization params.
+   * - {String} trusteeId - The unique id of a trustee.
+   */
   constructor({ trusteeId }) {
     this.trusteeId = trusteeId;
     this.electionId = null;
@@ -18,36 +25,11 @@ export class TrusteeWrapper {
     this.processedMessages = [];
   }
 
-  backup() {
-    return JSON.stringify(this);
-  }
-
-  checkRestoreNeeded(messageId) {
-    return messageId && this.status === CREATE_ELECTION;
-  }
-
-  restore(state, messageId) {
-    if (!this.checkRestoreNeeded(messageId)) {
-      return false;
-    }
-
-    const result = JSON.parse(state);
-    if (
-      result.trusteeId !== this.trusteeId ||
-      (messageId && result.status === CREATE_ELECTION)
-    ) {
-      return false;
-    }
-
-    try {
-      Object.assign(this, result);
-    } catch (error) {
-      return false;
-    }
-
-    return true;
-  }
-
+  /**
+   * Process the message and update the wrapper status.
+   *
+   * @returns {Object|undefined}
+   */
   processMessage(messageId, message) {
     const messageIdentifier = MessageIdentifier.parse(messageId);
     switch (this.status) {
@@ -101,5 +83,53 @@ export class TrusteeWrapper {
         break;
       }
     }
+  }
+
+  /**
+   * Whether the trustee wrapper state needs to be restored or not.
+   *
+   * @param {String} messageId - The unique identifier of a message.
+   * @returns {boolean}
+   */
+  needsToBeRestored(messageId) {
+    return messageId && this.status === CREATE_ELECTION;
+  }
+
+  /**
+   * Returns the wrapper state in a string format.
+   *
+   * @returns {String}
+   */
+  backup() {
+    return JSON.stringify(this);
+  }
+
+  /**
+   * Restore the trustee state from the given state string. It uses the last message sent to check that the state is valid.
+   *
+   * @param {string} state - As string with the wrapper state retrieved from the backup method.
+   * @param {messageId} messageId - The unique id of the last message sent by the trustee.
+   * @returns {boolean}
+   */
+  restore(state, messageId) {
+    if (!this.needsToBeRestored(messageId)) {
+      return false;
+    }
+
+    const result = JSON.parse(state);
+    if (
+      result.trusteeId !== this.trusteeId ||
+      (messageId && result.status === CREATE_ELECTION)
+    ) {
+      return false;
+    }
+
+    try {
+      Object.assign(this, result);
+    } catch (error) {
+      return false;
+    }
+
+    return true;
   }
 }

--- a/decidim-bulletin_board-js/src/trustee/trustee_wrapper_dummy.test.js
+++ b/decidim-bulletin_board-js/src/trustee/trustee_wrapper_dummy.test.js
@@ -1,4 +1,11 @@
-import { TrusteeWrapper } from "./trustee_wrapper_dummy";
+import {
+  TrusteeWrapper,
+  CREATE_ELECTION,
+  KEY_CEREMONY_STEP_1,
+  KEY_CEREMONY_JOINT_ELECTION_KEY,
+} from "./trustee_wrapper_dummy";
+
+import { MessageIdentifier, TRUSTEE_TYPE } from "../client/message-identifier";
 
 describe("TrusteeWrapper", () => {
   const defaultParams = {
@@ -15,26 +22,182 @@ describe("TrusteeWrapper", () => {
     wrapper = buildTrusteeWrapper();
   });
 
+  it("initialise the trustee wrapper with the given params", () => {
+    expect(wrapper.trusteeId).toEqual(defaultParams.trusteeId);
+    expect(wrapper.electionId).toEqual(null);
+    expect(wrapper.status).toEqual(CREATE_ELECTION);
+    expect(wrapper.electionTrusteesCount).toEqual(0);
+    expect(wrapper.processedMessages).toEqual([]);
+  });
+
+  describe("processMessage", () => {
+    describe("when the status is CREATE_ELECTION", () => {
+      beforeEach(() => {
+        wrapper.status = CREATE_ELECTION;
+      });
+
+      describe("when the message to be processed is the correct one", () => {
+        it("changes the wrapper status and store some data", () => {
+          const { done, save } = wrapper.processMessage(
+            MessageIdentifier.format(
+              "some-authority.some-id",
+              CREATE_ELECTION,
+              TRUSTEE_TYPE,
+              "some-author-id"
+            ),
+            {
+              trustees: ["trustee-1", "trustee-2"],
+            }
+          );
+          expect(wrapper.status).toEqual(KEY_CEREMONY_STEP_1);
+          expect(wrapper.electionId).toEqual("some-authority.some-id");
+          expect(wrapper.processedMessages).toEqual([]);
+          expect(wrapper.electionTrusteesCount).toEqual(2);
+          expect(done).toBeFalsy();
+          expect(save).toBeTruthy();
+        });
+      });
+
+      describe("when the message to be processes is not the correct one", () => {
+        it("doesn't do anything", () => {
+          wrapper.processMessage(
+            MessageIdentifier.format(
+              "some-authority.some-id",
+              "some-type",
+              TRUSTEE_TYPE,
+              "some-author-id"
+            ),
+            {}
+          );
+          expect(wrapper.status).toEqual(CREATE_ELECTION);
+        });
+      });
+    });
+
+    describe("when the status is KEY_CEREMONY_STEP_1", () => {
+      beforeEach(() => {
+        wrapper.status = KEY_CEREMONY_STEP_1;
+      });
+
+      describe("when the message to be processed is the correct one", () => {
+        describe("when there is not enough trustees", () => {
+          it("stores the message", () => {
+            wrapper.electionTrusteesCount = 2;
+            wrapper.processMessage(
+              MessageIdentifier.format(
+                "some-authority.some-id",
+                KEY_CEREMONY_STEP_1,
+                TRUSTEE_TYPE,
+                "some-author-id"
+              ),
+              {
+                trustee: "first-trustee",
+              }
+            );
+            expect(wrapper.status).toEqual(KEY_CEREMONY_STEP_1);
+            expect(wrapper.processedMessages).toEqual([
+              {
+                trustee: "first-trustee",
+              },
+            ]);
+          });
+        });
+
+        describe("when there is enough trustees", () => {
+          it("changes the wrapper status and store some data", () => {
+            wrapper.electionTrusteesCount = 1;
+            const { done, save } = wrapper.processMessage(
+              MessageIdentifier.format(
+                "some-authority.some-id",
+                KEY_CEREMONY_STEP_1,
+                TRUSTEE_TYPE,
+                "some-author-id"
+              ),
+              {
+                trustee: "first-trustee",
+              }
+            );
+            expect(wrapper.status).toEqual(KEY_CEREMONY_JOINT_ELECTION_KEY);
+            expect(done).toBeFalsy();
+            expect(save).toBeFalsy();
+          });
+        });
+      });
+
+      describe("when the message to be processes is not the correct one", () => {
+        it("doesn't do anything", () => {
+          wrapper.processMessage(
+            MessageIdentifier.format(
+              "some-authority.some-id",
+              "some-type",
+              TRUSTEE_TYPE,
+              "some-author-id"
+            ),
+            {}
+          );
+          expect(wrapper.status).toEqual(KEY_CEREMONY_STEP_1);
+        });
+      });
+    });
+
+    describe("when the status is KEY_CEREMONY_JOINT_ELECTION_KEY", () => {
+      beforeEach(() => {
+        wrapper.status = KEY_CEREMONY_JOINT_ELECTION_KEY;
+      });
+
+      describe("when the message to be processed is the correct one", () => {
+        it("returns some data", () => {
+          const { done, save } = wrapper.processMessage(
+            MessageIdentifier.format(
+              "some-authority.some-id",
+              KEY_CEREMONY_JOINT_ELECTION_KEY,
+              TRUSTEE_TYPE,
+              "some-author-id"
+            ),
+            {}
+          );
+          expect(done).toBeTruthy();
+          expect(save).toBeFalsy();
+        });
+      });
+
+      describe("when the message to be processes is not the correct one", () => {
+        it("doesn't do anything", () => {
+          wrapper.processMessage(
+            MessageIdentifier.format(
+              "some-authority.some-id",
+              "some-type",
+              TRUSTEE_TYPE,
+              "some-author-id"
+            ),
+            {}
+          );
+          expect(wrapper.status).toEqual(KEY_CEREMONY_JOINT_ELECTION_KEY);
+        });
+      });
+    });
+  });
+
+  describe("needsToBeRestored", () => {
+    it("returns false when there aren't messages sent by the Trustee", () => {
+      expect(wrapper.needsToBeRestored(null)).toBeFalsy();
+    });
+
+    it("returns false when the wrapper status is not the initial state", () => {
+      wrapper.status = "key_ceremony.step_1";
+      expect(wrapper.needsToBeRestored("key_ceremony.step_1")).toBeFalsy();
+    });
+
+    it("returns true when the wrapper status is the initial state and there are messages sent by the Trustee", () => {
+      expect(wrapper.needsToBeRestored("key_ceremony.step_1")).toBeTruthy();
+    });
+  });
+
   describe("backup", () => {
     it("returns a JSON representation of the wrapper", () => {
       expect(wrapper.backup()).toEqual(
         '{"trusteeId":"trustee-1","electionId":null,"status":"create_election","electionTrusteesCount":0,"processedMessages":[]}'
       );
-    });
-  });
-
-  describe("checkRestoreNeeded", () => {
-    it("returns false when there aren't messages sent by the Trustee", () => {
-      expect(wrapper.checkRestoreNeeded(null)).toBeFalsy();
-    });
-
-    it("returns false when the wrapper status is not the initial state", () => {
-      wrapper.status = "key_ceremony.step_1";
-      expect(wrapper.checkRestoreNeeded("key_ceremony.step_1")).toBeFalsy();
-    });
-
-    it("returns true when the wrapper status is the initial state and there are messages sent by the Trustee", () => {
-      expect(wrapper.checkRestoreNeeded("key_ceremony.step_1")).toBeTruthy();
     });
   });
 

--- a/decidim-bulletin_board-js/src/trustee/trustee_wrapper_dummy.test.js
+++ b/decidim-bulletin_board-js/src/trustee/trustee_wrapper_dummy.test.js
@@ -22,7 +22,7 @@ describe("TrusteeWrapper", () => {
     wrapper = buildTrusteeWrapper();
   });
 
-  it("initialise the trustee wrapper with the given params", () => {
+  it("initialises the trustee wrapper with the given params", () => {
     expect(wrapper.trusteeId).toEqual(defaultParams.trusteeId);
     expect(wrapper.electionId).toEqual(null);
     expect(wrapper.status).toEqual(CREATE_ELECTION);
@@ -37,7 +37,7 @@ describe("TrusteeWrapper", () => {
       });
 
       describe("when the message to be processed is the correct one", () => {
-        it("changes the wrapper status and store some data", () => {
+        it("changes the wrapper status and stores some data", () => {
           const { done, save } = wrapper.processMessage(
             MessageIdentifier.format(
               "some-authority.some-id",
@@ -80,7 +80,7 @@ describe("TrusteeWrapper", () => {
       });
 
       describe("when the message to be processed is the correct one", () => {
-        describe("when there is not enough trustees", () => {
+        describe("when there are not enough trustees", () => {
           it("stores the message", () => {
             wrapper.electionTrusteesCount = 2;
             wrapper.processMessage(
@@ -103,8 +103,8 @@ describe("TrusteeWrapper", () => {
           });
         });
 
-        describe("when there is enough trustees", () => {
-          it("changes the wrapper status and store some data", () => {
+        describe("when there are enough trustees", () => {
+          it("changes the wrapper status and stores some data", () => {
             wrapper.electionTrusteesCount = 1;
             const { done, save } = wrapper.processMessage(
               MessageIdentifier.format(

--- a/decidim-bulletin_board-ruby/CHANGELOG.md
+++ b/decidim-bulletin_board-ruby/CHANGELOG.md
@@ -7,10 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-### Added
+## Changed
 
+- The `KeyCeremony` class no longer receives an `electionContext` but an `election` object.
+- The `KeyCeremony` class now receives a `trustee` object.
+- `checkRestoreNeeded` method has been renamed to `needsToBeRestored` for both the `Trustee` and the `TrusteeWrapper`.
+- The `Trustee` class now uses the `Election` class to interact with the log entries.
+
+## Added
+
+- `Election` class in the JS package to handle the election state. An instance of this class will be used by the key ceremony and the trustee to check anything related to log entries.
+- The `KeyCeremony` class now have a `teardown` method that is called automatically to clean a few things. It can be called early to avoid memory leaks if needed.
 - `start_tally` method to the `Decidim::BulletinBoard::Client`.
 - `publish_results` method to the `Decidim::BulletinBoard::Client`.
+
+## Removed
+
+- The `KeyCeremony` class no longer have methods related to backup or restore. Use the `Trustee` class to perform these operations.
 
 ## [0.6.1] - 2021-01-12
 


### PR DESCRIPTION
This is the first step to implement the Tally in #67. I wanted to refactor our current codebase to make it easier. Since the `CHANGELOG.md` include all the changes I am going to paste it below.

This PR include some breaking changes that will be addressed in `decidim` after releasing a new version of the gem.

## Changed

- The `KeyCeremony` class no longer receives an `electionContext` but an `election` object.
- The `KeyCeremony` class now receives a `trustee` object.
- `checkRestoreNeeded` method has been renamed to `needsToBeRestored` for both the `Trustee` and the `TrusteeWrapper`.
- The `Trustee` class now uses the `Election` class to interact with the log entries.

## Added

- `Election` class in the JS package to handle the election state. An instance of this class will be used by the key ceremony and the trustee to check anything related to log entries.
- The `KeyCeremony` class now have a `teardown` method that is called automatically to clean a few things. It can be called early to avoid memory leaks if needed.

## Removed

- The `KeyCeremony` class no longer have methods related to backup or restore. Use the `Trustee` class to perform these operations.
