### PR TITLE
chore: enhance seeds to include more log entries

### DIFF
--- a/decidim-bulletin_board-app/db/seeds.rb
+++ b/decidim-bulletin_board-app/db/seeds.rb
@@ -5,6 +5,49 @@ exit if Rails.env.production? && !ENV["SEED"]
 require "factory_bot_rails"
 require "test/private_keys"
 
+def create_key_ceremony_log_entries(election)
+  Test::PrivateKeys.trustees_private_keys.each_with_index do |trustee_private_key, index|
+    trustee = Trustee.find_by(name: "Decidim Test Trustee #{index + 1}")
+    FactoryBot.create(:log_entry,
+                      election: election,
+                      client: trustee,
+                      private_key: trustee_private_key,
+                      message: FactoryBot.build(:key_ceremony_message,
+                                                election: election,
+                                                trustee: trustee))
+  end
+end
+
+def create_joint_election_key_log_entry(election)
+  FactoryBot.create(:log_entry,
+                    election: election,
+                    message: FactoryBot.build(:key_ceremony_message_joint_election_message,
+                                              election: election))
+end
+
+def create_open_ballot_box_log_entry(election)
+  FactoryBot.create(:log_entry,
+                    election: election,
+                    message: FactoryBot.build(:open_ballot_box_message,
+                                              election: election))
+end
+
+def create_vote_log_entries(election, amount = 3)
+  amount.times do
+    FactoryBot.create(:log_entry,
+                      election: election,
+                      message: FactoryBot.build(:vote_message,
+                                                election: election))
+  end
+end
+
+def create_close_ballot_box_log_entry(election)
+  FactoryBot.create(:log_entry,
+                    election: election,
+                    message: FactoryBot.build(:close_ballot_box_message,
+                                              election: election))
+end
+
 Authority.create!(
   name: "Decidim Test Authority",
   public_key: Test::PrivateKeys.authority_public_key,
@@ -22,5 +65,33 @@ end
 
 TEST_ELECTION_ID_OFFSET = 10_000
 [:key_ceremony, :ready, :vote, :tally, :results, :results_published].each_with_index do |status, i|
-  FactoryBot.create(:election, election_id: TEST_ELECTION_ID_OFFSET + i, status: status)
+  election = FactoryBot.create(:election, election_id: TEST_ELECTION_ID_OFFSET + i, status: status)
+
+  case status
+  when :ready
+    create_key_ceremony_log_entries(election)
+    create_joint_election_key_log_entry(election)
+  when :vote
+    create_key_ceremony_log_entries(election)
+    create_joint_election_key_log_entry(election)
+    create_open_ballot_box_log_entry(election)
+  when :tally
+    create_key_ceremony_log_entries(election)
+    create_joint_election_key_log_entry(election)
+    create_open_ballot_box_log_entry(election)
+    create_vote_log_entries(election)
+    create_close_ballot_box_log_entry(election)
+  when :results
+    create_key_ceremony_log_entries(election)
+    create_joint_election_key_log_entry(election)
+    create_open_ballot_box_log_entry(election)
+    create_vote_log_entries(election)
+    create_close_ballot_box_log_entry(election)
+  when :results_published
+    create_key_ceremony_log_entries(election)
+    create_joint_election_key_log_entry(election)
+    create_open_ballot_box_log_entry(election)
+    create_vote_log_entries(election)
+    create_close_ballot_box_log_entry(election)
+  end
 end

--- a/decidim-bulletin_board-app/spec/factories/messages.rb
+++ b/decidim-bulletin_board-app/spec/factories/messages.rb
@@ -145,9 +145,17 @@ FactoryBot.define do
       transient do
         election { create(:election) }
         trustee { Trustee.first }
+        voting_scheme { :dummy }
       end
 
-      message_id { "#{election.unique_id}.key_ceremony.trustee_election_keys+t.#{trustee.unique_id}" }
+      message_id do
+        case voting_scheme
+        when :dummy
+          "#{election.unique_id}.key_ceremony.step_1+t.#{trustee.unique_id}"
+        else
+          "#{election.unique_id}.key_ceremony.trustee_election_keys+t.#{trustee.unique_id}"
+        end
+      end
       content { build(:key_ceremony_message_content, *content_traits, election: election, trustee: trustee).to_json }
     end
 
@@ -164,6 +172,23 @@ FactoryBot.define do
       trait :invalid do
         owner_id { "wrong_trustee" }
       end
+    end
+
+    factory :key_ceremony_message_joint_election_message, parent: :message do
+      transient do
+        election { create(:election) }
+      end
+
+      message_id { "#{election.unique_id}.key_ceremony.joint_election_key+b.bulletin-board" }
+      content { build(:key_ceremony_message_joint_election_message_content, *content_traits, election: election).to_json }
+    end
+
+    factory :key_ceremony_message_joint_election_message_content do
+      transient do
+        election { create(:election) }
+      end
+
+      joint_election_key { 3.pow(election.manifest["trustees"].length) }
     end
 
     factory :open_ballot_box_message, parent: :message do


### PR DESCRIPTION
I wanted to test the Tally client, and then I realized that our seeds are missing some log entries. I decided to enhance them to include more log entries in an election depending on the status. This will help to test things in the sandbox that I am building here #68 

https://user-images.githubusercontent.com/106021/105348879-3a62e780-5be9-11eb-90a1-f2fa808df00e.mov

