### PR TITLE
chore: add timeout to encrypt method

### DIFF
--- a/decidim-bulletin_board-js/src/voter/voter_wrapper_dummy.js
+++ b/decidim-bulletin_board-js/src/voter/voter_wrapper_dummy.js
@@ -2,12 +2,17 @@
  * This is just a dummy implementation of a possible `VoterWrapper`.
  * It is based on the dummy voting schema that we are using in the Bulletin Board.
  */
+
+export const WAIT_TIME_MS = 500; // 0.5s
+
 export class VoterWrapper {
   constructor({ voterId }) {
     this.voterId = voterId;
   }
 
   encrypt(data) {
-    return JSON.stringify(data);
+    return new Promise((resolve) =>
+      setTimeout(resolve, WAIT_TIME_MS)
+    ).then(() => JSON.stringify(data));
   }
 }

--- a/decidim-bulletin_board-ruby/CHANGELOG.md
+++ b/decidim-bulletin_board-ruby/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Changed
+
+- `encrypt` in `VoterWrapperDummy` has a TimeOut of 500ms.
+
 ## [0.8.0] - 2021-01-27
 
 ## Changed


### PR DESCRIPTION
This PR adds a Timeout of 500ms to the `encrypt` method of the Voter Dummy to be more realistic.