### PR TITLE
chore: update gem 0.8.2

### DIFF
--- a/decidim-bulletin_board-app/Gemfile.lock
+++ b/decidim-bulletin_board-app/Gemfile.lock
@@ -79,7 +79,7 @@ GEM
     database_cleaner-active_record (1.8.0)
       activerecord
       database_cleaner (~> 1.8.0)
-    decidim-bulletin_board (0.8.0)
+    decidim-bulletin_board (0.8.2)
       byebug (~> 11.0)
       graphlient (~> 0.4.0)
       jwt (~> 2.2.2)
@@ -116,7 +116,7 @@ GEM
       faraday (>= 1.0)
       faraday_middleware
       graphql-client
-    graphql (1.12.1)
+    graphql (1.12.3)
     graphql-client (0.16.0)
       activesupport (>= 3.0)
       graphql (~> 1.8)


### PR DESCRIPTION
This PR updates the `decidim-bulletin_board` gem for the app to version 0.8.2