### PR TITLE
feat: apply pending message checking for votes to admin actions

### DIFF
--- a/decidim-bulletin_board-app/app/commands/enqueue_message.rb
+++ b/decidim-bulletin_board-app/app/commands/enqueue_message.rb
@@ -28,8 +28,8 @@ class EnqueueMessage < Rectify::Command
 
     transaction do
       create_pending_message!
-      job.perform_later(pending_message.id)
     end
+    job.perform_later(pending_message.id)
 
     broadcast(:ok, pending_message)
   end

--- a/decidim-bulletin_board-js/src/client/client.js
+++ b/decidim-bulletin_board-js/src/client/client.js
@@ -63,14 +63,26 @@ export class Client {
   }
 
   /**
-   * Query PendingMessages for a given messageId
+   * Wait until a pending message is processed
    *
-   * @param {Object} params - An object that include the following options.
-   *  - {String} messageId - The messageId
-   * @returns {Promise<Object>} - The pending message received.
-   * @throws Will throw an error if the request is rejected.
+   * @param {Object} messageId - An object that includes the following options.
+   *  - {String} messageId - the unique identifier of a message
+   * @returns {Promise<Object>} - Returns the PendingMessage
    */
-  getPendingMessageByMessageId({ messageId }) {
-    return this.apiClient.getPendingMessageByMessageId({ messageId });
+  waitForPendingMessageToBeProcessed(messageId) {
+    return new Promise((resolve, reject) => {
+      const intervalId = setInterval(() => {
+        this.apiClient
+          .getPendingMessageByMessageId({
+            messageId,
+          })
+          .then((pendingMessage) => {
+            if (pendingMessage.status !== "enqueued") {
+              clearInterval(intervalId);
+              resolve(pendingMessage);
+            }
+          });
+      }, this.options.bulletinBoardWaitTime);
+    });
   }
 }

--- a/decidim-bulletin_board-js/src/client/client.js
+++ b/decidim-bulletin_board-js/src/client/client.js
@@ -1,5 +1,7 @@
 import { GraphQLClient } from "./graphql-client";
 
+export const WAIT_TIME_MS = 1_000; // 1s
+
 /**
  * This is a facade over the API client specific implementation.
  */
@@ -65,12 +67,12 @@ export class Client {
   /**
    * Wait until a pending message is processed
    *
-   * @param {Object} messageId - An object that includes the following options.
-   *  - {String} messageId - the unique identifier of a message
+   * @param {String} messageId - the unique identifier of a message
+   * @param {Integer} [waitTime=WAIT_TIME_MS] - the interval to wait for the pending message to be processed
    * @returns {Promise<Object>} - Returns the PendingMessage
    */
-  waitForPendingMessageToBeProcessed(messageId) {
-    return new Promise((resolve, reject) => {
+  waitForPendingMessageToBeProcessed(messageId, waitTime = WAIT_TIME_MS) {
+    return new Promise((resolve) => {
       const intervalId = setInterval(() => {
         this.apiClient
           .getPendingMessageByMessageId({
@@ -82,7 +84,7 @@ export class Client {
               resolve(pendingMessage);
             }
           });
-      }, this.options.bulletinBoardWaitTime);
+      }, waitTime);
     });
   }
 }

--- a/decidim-bulletin_board-js/src/client/client.test.js
+++ b/decidim-bulletin_board-js/src/client/client.test.js
@@ -5,7 +5,6 @@ jest.mock("./graphql-client");
 describe("Client", () => {
   const defaultParams = {
     apiEndpointUrl: "https://example.org/api",
-    wsEndpointUrl: "wss://example.org/ws",
   };
 
   const buildClient = (params = defaultParams) => {
@@ -47,11 +46,11 @@ describe("Client", () => {
     });
   });
 
-  describe("getPendingMessageByMessageId", () => {
+  describe("waitForPendingMessageToBeProcessed", () => {
     it("returns the pending message for the given messageId", async () => {
-      const pendingMessage = await client.getPendingMessageByMessageId({
-        messageId: "dummy.1",
-      });
+      const pendingMessage = await client.waitForPendingMessageToBeProcessed(
+        "dummy.1"
+      );
       expect(pendingMessage).toEqual({
         status: "accepted",
       });

--- a/decidim-bulletin_board-js/src/client/graphql-client.test.js
+++ b/decidim-bulletin_board-js/src/client/graphql-client.test.js
@@ -14,7 +14,6 @@ describe("GraphQLClient", () => {
   beforeEach(() => {
     client = new GraphQLClient({
       apiEndpointUrl: "https://example.org/api",
-      wsEndpointUrl: "wss://example.org/cable",
     });
   });
 

--- a/decidim-bulletin_board-js/src/voter/voter.js
+++ b/decidim-bulletin_board-js/src/voter/voter.js
@@ -55,30 +55,6 @@ export class Voter {
   }
 
   /**
-   * Confirms if a vote was processed
-   *
-   * @param {Object} messageId - An object that includes the following options.
-   *  - {String} messageId - the unique identifier of a message
-   * @returns {Promise<Object>} - Returns the PendingMessage
-   */
-  waitForPendingMessageToBeProcessed(messageId) {
-    return new Promise((resolve, reject) => {
-      const intervalId = setInterval(() => {
-        this.bulletinBoardClient
-          .getPendingMessageByMessageId({
-            messageId,
-          })
-          .then((pendingMessage) => {
-            if (pendingMessage.status !== "enqueued") {
-              clearInterval(intervalId);
-              resolve(pendingMessage);
-            }
-          });
-      }, this.options.bulletinBoardWaitTime);
-    });
-  }
-
-  /**
    * Verifies a vote
    *
    * @param {String} contentHash - An object that includes the following options.

--- a/decidim-bulletin_board-js/src/voter/voter.js
+++ b/decidim-bulletin_board-js/src/voter/voter.js
@@ -1,8 +1,6 @@
 import { VoterWrapper } from "./voter_wrapper_dummy";
 import { JWTParser } from "../jwt_parser";
 
-export const WAIT_TIME_MS = 1_000; // 1s
-
 /**
  * This is a facade class that will use the correspondig `VoterWrapper` to encrypt
  * the vote.
@@ -15,13 +13,12 @@ export class Voter {
    * @param {Object} params - An object that contains the initialization params.
    *  - {String} id - The voter identifier.
    */
-  constructor({ id, electionContext, bulletinBoardClient, options }) {
+  constructor({ id, electionContext, bulletinBoardClient }) {
     this.id = id;
     this.electionContext = electionContext;
     this.bulletinBoardClient = bulletinBoardClient;
     this.wrapper = new VoterWrapper({ voterId: id });
     this.parser = new JWTParser();
-    this.options = options || { bulletinBoardWaitTime: WAIT_TIME_MS };
   }
 
   /**

--- a/decidim-bulletin_board-ruby/CHANGELOG.md
+++ b/decidim-bulletin_board-ruby/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Changed
 
 - The `open_ballot_box` and `close_ballot_box` are now called `start_vote` and `end_vote` and return a pending message.
+- All the client operations yield the `message_id` before sending the request to the Bulletin Board.
 
 ## Added
 

--- a/decidim-bulletin_board-ruby/Gemfile.lock
+++ b/decidim-bulletin_board-ruby/Gemfile.lock
@@ -76,7 +76,8 @@ GEM
     builder (3.2.4)
     byebug (11.1.3)
     concurrent-ruby (1.1.7)
-    crack (0.4.4)
+    crack (0.4.5)
+      rexml
     crass (1.0.6)
     diff-lcs (1.4.4)
     erubi (1.10.0)
@@ -205,7 +206,7 @@ GEM
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.7.0)
-    webmock (3.10.0)
+    webmock (3.11.2)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)

--- a/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/authority/create_election.rb
+++ b/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/authority/create_election.rb
@@ -10,8 +10,12 @@ module Decidim
           @election_data = election_data
         end
 
+        # Returns the message_id related to the operation
+        def message_id
+          @message_id ||= message_id(unique_election_id(election_id), "create_election")
+        end
+
         def call
-          message_id = message_id(unique_election_id(election_id), "create_election")
           signed_data = sign_message(message_id, election_data)
 
           begin

--- a/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/authority/end_vote.rb
+++ b/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/authority/end_vote.rb
@@ -12,6 +12,11 @@ module Decidim
           @election_id = election_id
         end
 
+        # Returns the message_id related to the operation
+        def message_id
+          @message_id ||= message_id(unique_election_id(election_id), "end_vote")
+        end
+
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid and the query operation is successful.
@@ -19,7 +24,6 @@ module Decidim
         #
         # Returns nothing.
         def call
-          message_id = message_id(unique_election_id(election_id), "end_vote")
           signed_data = sign_message(message_id, {})
 
           begin

--- a/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/authority/end_vote.rb
+++ b/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/authority/end_vote.rb
@@ -14,7 +14,7 @@ module Decidim
 
         # Returns the message_id related to the operation
         def message_id
-          @message_id ||= message_id(unique_election_id(election_id), "end_vote")
+          @message_id ||= build_message_id(unique_election_id(election_id), "end_vote")
         end
 
         # Executes the command. Broadcasts these events:
@@ -24,17 +24,19 @@ module Decidim
         #
         # Returns nothing.
         def call
-          signed_data = sign_message(message_id, {})
+          # arguments used inside the graphql operation
+          args = {
+            message_id: message_id,
+            signed_data: sign_message(message_id, {})
+          }
 
-          begin
-            response = client.query do
-              mutation do
-                endVote(messageId: message_id, signedData: signed_data) do
-                  pendingMessage do
-                    status
-                  end
-                  error
+          response = client.query do
+            mutation do
+              endVote(messageId: args[:message_id], signedData: args[:signed_data]) do
+                pendingMessage do
+                  status
                 end
+                error
               end
             end
           end

--- a/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/authority/get_election_status.rb
+++ b/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/authority/get_election_status.rb
@@ -19,21 +19,22 @@ module Decidim
         #
         # Returns nothing.
         def call
-          unique_id = unique_election_id(election_id)
+          # arguments used inside the graphql operation
+          args = {
+            unique_id: unique_election_id(election_id)
+          }
 
-          begin
-            response = client.query do
-              query do
-                election(uniqueId: unique_id) do
-                  status
-                end
+          response = client.query do
+            query do
+              election(uniqueId: args[:unique_id]) do
+                status
               end
             end
-
-            broadcast(:ok, response.data.election.status)
-          rescue Graphlient::Errors::ServerError
-            broadcast(:error, "Sorry, something went wrong")
           end
+
+          broadcast(:ok, response.data.election.status)
+        rescue Graphlient::Errors::ServerError
+          broadcast(:error, "Sorry, something went wrong")
         end
 
         private

--- a/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/authority/publish_results.rb
+++ b/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/authority/publish_results.rb
@@ -12,6 +12,11 @@ module Decidim
           @election_id = election_id
         end
 
+        # Returns the message_id related to the operation
+        def message_id
+          @message_id ||= message_id(unique_election_id(election_id), "publish_results")
+        end
+
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid and the query operation is successful.
@@ -19,7 +24,6 @@ module Decidim
         #
         # Returns nothing.
         def call
-          message_id = message_id(unique_election_id(election_id), "publish_results")
           signed_data = sign_message(message_id, {})
 
           begin

--- a/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/authority/publish_results.rb
+++ b/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/authority/publish_results.rb
@@ -14,7 +14,7 @@ module Decidim
 
         # Returns the message_id related to the operation
         def message_id
-          @message_id ||= message_id(unique_election_id(election_id), "publish_results")
+          @message_id ||= build_message_id(unique_election_id(election_id), "publish_results")
         end
 
         # Executes the command. Broadcasts these events:
@@ -24,26 +24,28 @@ module Decidim
         #
         # Returns nothing.
         def call
-          signed_data = sign_message(message_id, {})
+          # arguments used inside the graphql operation
+          args = {
+            message_id: message_id,
+            signed_data: sign_message(message_id, {})
+          }
 
-          begin
-            response = client.query do
-              mutation do
-                publishResults(messageId: message_id, signedData: signed_data) do
-                  election do
-                    status
-                  end
-                  error
+          response = client.query do
+            mutation do
+              publishResults(messageId: args[:message_id], signedData: args[:signed_data]) do
+                election do
+                  status
                 end
+                error
               end
             end
-
-            return broadcast(:error, response.data.publish_results.error) if response.data.publish_results.error.present?
-
-            broadcast(:ok, response.data.publish_results.election)
-          rescue Graphlient::Errors::ServerError
-            broadcast(:error, "Sorry, something went wrong")
           end
+
+          return broadcast(:error, response.data.publish_results.error) if response.data.publish_results.error.present?
+
+          broadcast(:ok, response.data.publish_results.election)
+        rescue Graphlient::Errors::ServerError
+          broadcast(:error, "Sorry, something went wrong")
         end
 
         private

--- a/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/authority/start_key_ceremony.rb
+++ b/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/authority/start_key_ceremony.rb
@@ -12,6 +12,11 @@ module Decidim
           @election_id = election_id
         end
 
+        # Returns the message_id related to the operation
+        def message_id
+          @message_id ||= message_id(unique_election_id(election_id), "start_key_ceremony")
+        end
+
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid and the query operation is successful.
@@ -19,7 +24,6 @@ module Decidim
         #
         # Returns nothing.
         def call
-          message_id = message_id(unique_election_id(election_id), "start_key_ceremony")
           signed_data = sign_message(message_id, {})
 
           begin

--- a/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/authority/start_key_ceremony.rb
+++ b/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/authority/start_key_ceremony.rb
@@ -14,7 +14,7 @@ module Decidim
 
         # Returns the message_id related to the operation
         def message_id
-          @message_id ||= message_id(unique_election_id(election_id), "start_key_ceremony")
+          @message_id ||= build_message_id(unique_election_id(election_id), "start_key_ceremony")
         end
 
         # Executes the command. Broadcasts these events:
@@ -24,17 +24,19 @@ module Decidim
         #
         # Returns nothing.
         def call
-          signed_data = sign_message(message_id, {})
+          # arguments used inside the graphql operation
+          args = {
+            message_id: message_id,
+            signed_data: sign_message(message_id, {})
+          }
 
-          begin
-            response = client.query do
-              mutation do
-                startKeyCeremony(messageId: message_id, signedData: signed_data) do
-                  pendingMessage do
-                    status
-                  end
-                  error
+          response = client.query do
+            mutation do
+              startKeyCeremony(messageId: args[:message_id], signedData: args[:signed_data]) do
+                pendingMessage do
+                  status
                 end
+                error
               end
             end
           end

--- a/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/authority/start_tally.rb
+++ b/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/authority/start_tally.rb
@@ -12,6 +12,11 @@ module Decidim
           @election_id = election_id
         end
 
+        # Returns the message_id related to the operation
+        def message_id
+          @message_id ||= message_id(unique_election_id(election_id), "start_tally")
+        end
+
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid and the query operation is successful.
@@ -19,7 +24,6 @@ module Decidim
         #
         # Returns nothing.
         def call
-          message_id = message_id(unique_election_id(election_id), "start_tally")
           signed_data = sign_message(message_id, {})
 
           begin

--- a/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/authority/start_tally.rb
+++ b/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/authority/start_tally.rb
@@ -14,7 +14,7 @@ module Decidim
 
         # Returns the message_id related to the operation
         def message_id
-          @message_id ||= message_id(unique_election_id(election_id), "start_tally")
+          @message_id ||= build_message_id(unique_election_id(election_id), "start_tally")
         end
 
         # Executes the command. Broadcasts these events:
@@ -24,26 +24,28 @@ module Decidim
         #
         # Returns nothing.
         def call
-          signed_data = sign_message(message_id, {})
+          # arguments used inside the graphql operation
+          args = {
+            message_id: message_id,
+            signed_data: sign_message(message_id, {})
+          }
 
-          begin
-            response = client.query do
-              mutation do
-                startTally(messageId: message_id, signedData: signed_data) do
-                  pendingMessage do
-                    status
-                  end
-                  error
+          response = client.query do
+            mutation do
+              startTally(messageId: args[:message_id], signedData: args[:signed_data]) do
+                pendingMessage do
+                  status
                 end
+                error
               end
             end
-
-            return broadcast(:error, response.data.start_tally.error) if response.data.start_tally.error.present?
-
-            broadcast(:ok, response.data.start_tally.pending_message)
-          rescue Graphlient::Errors::ServerError
-            broadcast(:error, "Sorry, something went wrong")
           end
+
+          return broadcast(:error, response.data.start_tally.error) if response.data.start_tally.error.present?
+
+          broadcast(:ok, response.data.start_tally.pending_message)
+        rescue Graphlient::Errors::ServerError
+          broadcast(:error, "Sorry, something went wrong")
         end
 
         private

--- a/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/authority/start_vote.rb
+++ b/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/authority/start_vote.rb
@@ -12,6 +12,11 @@ module Decidim
           @election_id = election_id
         end
 
+        # Returns the message_id related to the operation
+        def message_id
+          @message_id ||= message_id(unique_election_id(election_id), "start_vote")
+        end
+
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid and the query operation is successful.
@@ -19,7 +24,6 @@ module Decidim
         #
         # Returns nothing.
         def call
-          message_id = message_id(unique_election_id(election_id), "start_vote")
           signed_data = sign_message(message_id, {})
 
           begin

--- a/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/authority/start_vote.rb
+++ b/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/authority/start_vote.rb
@@ -14,7 +14,7 @@ module Decidim
 
         # Returns the message_id related to the operation
         def message_id
-          @message_id ||= message_id(unique_election_id(election_id), "start_vote")
+          @message_id ||= build_message_id(unique_election_id(election_id), "start_vote")
         end
 
         # Executes the command. Broadcasts these events:
@@ -24,17 +24,19 @@ module Decidim
         #
         # Returns nothing.
         def call
-          signed_data = sign_message(message_id, {})
+          # arguments used inside the graphql operation
+          args = {
+            message_id: message_id,
+            signed_data: sign_message(message_id, {})
+          }
 
-          begin
-            response = client.query do
-              mutation do
-                startVote(messageId: message_id, signedData: signed_data) do
-                  pendingMessage do
-                    status
-                  end
-                  error
+          response = client.query do
+            mutation do
+              startVote(messageId: args[:message_id], signedData: args[:signed_data]) do
+                pendingMessage do
+                  status
                 end
+                error
               end
             end
           end

--- a/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/client.rb
+++ b/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/client.rb
@@ -34,6 +34,7 @@ module Decidim
 
       def create_election(election_id, election_data)
         create_election = Decidim::BulletinBoard::Authority::CreateElection.new(election_id, election_data)
+        yield create_election.message_id if block_given?
         create_election.on(:ok) { |election| return election }
         create_election.on(:error) { |error_message| raise StandardError, error_message }
         create_election.call
@@ -41,6 +42,7 @@ module Decidim
 
       def start_key_ceremony(election_id)
         start_key_ceremony = Decidim::BulletinBoard::Authority::StartKeyCeremony.new(election_id)
+        yield start_key_ceremony.message_id if block_given?
         start_key_ceremony.on(:ok) { |pending_message| return pending_message }
         start_key_ceremony.on(:error) { |error_message| raise StandardError, error_message }
         start_key_ceremony.call
@@ -48,17 +50,15 @@ module Decidim
 
       def start_vote(election_id)
         start_vote = Decidim::BulletinBoard::Authority::StartVote.new(election_id)
+        yield start_vote.message_id if block_given?
         start_vote.on(:ok) { |pending_message| return pending_message }
         start_vote.on(:error) { |error_message| raise StandardError, error_message }
         start_vote.call
       end
 
-      def cast_vote_message_id(election_id, voter_id)
-        Decidim::BulletinBoard::Voter::CastVote.cast_vote_message_id(election_id, voter_id)
-      end
-
       def cast_vote(election_id, voter_id, encrypted_vote)
         cast_vote = Decidim::BulletinBoard::Voter::CastVote.new(election_id, voter_id, encrypted_vote)
+        yield cast_vote.message_id if block_given?
         cast_vote.on(:ok) { |pending_message| return pending_message }
         cast_vote.on(:error) { |error_message| raise StandardError, error_message }
         cast_vote.call
@@ -73,6 +73,7 @@ module Decidim
 
       def end_vote(election_id)
         end_vote = Decidim::BulletinBoard::Authority::EndVote.new(election_id)
+        yield end_vote.message_id if block_given?
         end_vote.on(:ok) { |pending_message| return pending_message }
         end_vote.on(:error) { |error_message| raise StandardError, error_message }
         end_vote.call
@@ -87,6 +88,7 @@ module Decidim
 
       def start_tally(election_id)
         start_tally = Decidim::BulletinBoard::Authority::StartTally.new(election_id)
+        yield start_tally.message_id if block_given?
         start_tally.on(:ok) { |pending_message| return pending_message }
         start_tally.on(:error) { |error_message| raise StandardError, error_message }
         start_tally.call
@@ -94,6 +96,7 @@ module Decidim
 
       def publish_results(election_id)
         publish_results = Decidim::BulletinBoard::Authority::PublishResults.new(election_id)
+        yield publish_results.message_id if block_given?
         publish_results.on(:ok) { |status| return status }
         publish_results.on(:error) { |error_message| raise StandardError, error_message }
         publish_results.call

--- a/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/command.rb
+++ b/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/command.rb
@@ -8,7 +8,7 @@ module Decidim
     class Command
       include Wisper::Publisher
 
-      delegate :authority_slug, :private_key, :unique_election_id, :message_id, to: :class
+      delegate :authority_slug, :private_key, :unique_election_id, :build_message_id, to: :class
 
       def sign_message(message_id, message)
         JWT.encode(complete_message(message_id, message), private_key.keypair, "RS256")
@@ -42,7 +42,7 @@ module Decidim
           Decidim::BulletinBoard::MessageIdentifier.unique_election_id(authority_slug, election_id)
         end
 
-        def message_id(unique_election_id, type_subtype, voter_id = nil)
+        def build_message_id(unique_election_id, type_subtype, voter_id = nil)
           Decidim::BulletinBoard::MessageIdentifier.format(unique_election_id, type_subtype, voter_id ? :voter : :authority, voter_id || authority_slug)
         end
       end

--- a/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/voter/cast_vote.rb
+++ b/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/voter/cast_vote.rb
@@ -25,7 +25,8 @@ module Decidim
         # - :error if the form wasn't valid or the mutation operation was not successful.
         #
         # Returns nothing.
-        def call          # arguments used inside the graphql operation
+        def call
+          # arguments used inside the graphql operation
           args = {
             message_id: message_id,
             signed_data: sign_message(message_id, { content: encrypted_vote })

--- a/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/voter/cast_vote.rb
+++ b/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/voter/cast_vote.rb
@@ -14,6 +14,11 @@ module Decidim
           @encrypted_vote = encrypted_vote
         end
 
+        # Returns the message_id related to the operation
+        def message_id
+          @message_id ||= message_id(unique_election_id(election_id), "vote.cast", voter_id)
+        end
+
         # Executes the command. Broadcasts these events:
         #
         # - :ok when everything is valid and the mutation operation is successful.
@@ -21,7 +26,6 @@ module Decidim
         #
         # Returns nothing.
         def call
-          message_id = cast_vote_message_id(election_id, voter_id)
           signed_data = sign_message(message_id, { content: encrypted_vote })
 
           begin
@@ -29,6 +33,7 @@ module Decidim
               mutation do
                 vote(messageId: message_id, signedData: signed_data) do
                   pendingMessage do
+                    messageId
                     status
                   end
                   error
@@ -42,10 +47,6 @@ module Decidim
           rescue Graphlient::Errors::FaradayServerError
             broadcast(:error, "something went wrong")
           end
-        end
-
-        def self.cast_vote_message_id(election_id, voter_id)
-          message_id(unique_election_id(election_id), "vote.cast", voter_id)
         end
 
         private

--- a/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/voter/cast_vote.rb
+++ b/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/voter/cast_vote.rb
@@ -25,14 +25,16 @@ module Decidim
         # - :error if the form wasn't valid or the mutation operation was not successful.
         #
         # Returns nothing.
-        def call
-          mid = message_id
-          signed_data = sign_message(mid, { content: encrypted_vote })
+        def call          # arguments used inside the graphql operation
+          args = {
+            message_id: message_id,
+            signed_data: sign_message(message_id, { content: encrypted_vote })
+          }
 
           begin
             response = client.query do
               mutation do
-                vote(messageId: mid, signedData: signed_data) do
+                vote(messageId: args[:message_id], signedData: args[:signed_data]) do
                   pendingMessage do
                     messageId
                     status

--- a/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/voter/cast_vote.rb
+++ b/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/voter/cast_vote.rb
@@ -16,7 +16,7 @@ module Decidim
 
         # Returns the message_id related to the operation
         def message_id
-          @message_id ||= message_id(unique_election_id(election_id), "vote.cast", voter_id)
+          @message_id ||= build_message_id(unique_election_id(election_id), "vote.cast", voter_id)
         end
 
         # Executes the command. Broadcasts these events:
@@ -26,12 +26,13 @@ module Decidim
         #
         # Returns nothing.
         def call
-          signed_data = sign_message(message_id, { content: encrypted_vote })
+          mid = message_id
+          signed_data = sign_message(mid, { content: encrypted_vote })
 
           begin
             response = client.query do
               mutation do
-                vote(messageId: message_id, signedData: signed_data) do
+                vote(messageId: mid, signedData: signed_data) do
                   pendingMessage do
                     messageId
                     status

--- a/decidim-bulletin_board-ruby/spec/decidim/bulletin_board/authority/create_election_spec.rb
+++ b/decidim-bulletin_board-ruby/spec/decidim/bulletin_board/authority/create_election_spec.rb
@@ -32,6 +32,10 @@ module Decidim
             expect { subject.call }.to broadcast(:ok)
           end
 
+          it "build the right message_id" do
+            expect(subject.message_id).to eq("decidim-test-authority.1.create_election+a.decidim-test-authority")
+          end
+
           it "uses the graphql client to open the ballot box and return the election" do
             subject.on(:ok) do |election|
               expect(election.status).to eq("created")

--- a/decidim-bulletin_board-ruby/spec/decidim/bulletin_board/authority/end_vote_spec.rb
+++ b/decidim-bulletin_board-ruby/spec/decidim/bulletin_board/authority/end_vote_spec.rb
@@ -27,6 +27,10 @@ module Decidim
             expect { subject.call }.to broadcast(:ok)
           end
 
+          it "build the right message_id" do
+            expect(subject.message_id).to eq("decidim-test-authority.decidim-test-authority.1.end_vote+a.decidim-test-authority")
+          end
+
           it "uses the graphql client to end the voting period and returns its result" do
             subject.on(:ok) do |pending_message|
               expect(pending_message.status).to eq("enqueued")

--- a/decidim-bulletin_board-ruby/spec/decidim/bulletin_board/authority/publish_results_spec.rb
+++ b/decidim-bulletin_board-ruby/spec/decidim/bulletin_board/authority/publish_results_spec.rb
@@ -27,6 +27,10 @@ module Decidim
             expect { subject.call }.to broadcast(:ok)
           end
 
+          it "build the right message_id" do
+            expect(subject.message_id).to eq("decidim-test-authority.decidim-test-authority.1.publish_results+a.decidim-test-authority")
+          end
+
           it "uses the graphql client to publish the election results and returns its result" do
             subject.on(:ok) do |election|
               expect(election.status).to eq("results_published")

--- a/decidim-bulletin_board-ruby/spec/decidim/bulletin_board/authority/start_key_ceremony_spec.rb
+++ b/decidim-bulletin_board-ruby/spec/decidim/bulletin_board/authority/start_key_ceremony_spec.rb
@@ -27,6 +27,10 @@ module Decidim
             expect { subject.call }.to broadcast(:ok)
           end
 
+          it "build the right message_id" do
+            expect(subject.message_id).to eq("decidim-test-authority.decidim-test-authority.1.start_key_ceremony+a.decidim-test-authority")
+          end
+
           it "uses the graphql client to start the key ceremony and returns its result" do
             subject.on(:ok) do |pending_message|
               expect(pending_message.status).to eq("enqueued")

--- a/decidim-bulletin_board-ruby/spec/decidim/bulletin_board/authority/start_tally_spec.rb
+++ b/decidim-bulletin_board-ruby/spec/decidim/bulletin_board/authority/start_tally_spec.rb
@@ -27,6 +27,10 @@ module Decidim
             expect { subject.call }.to broadcast(:ok)
           end
 
+          it "build the right message_id" do
+            expect(subject.message_id).to eq("decidim-test-authority.decidim-test-authority.1.start_tally+a.decidim-test-authority")
+          end
+
           it "uses the graphql client to start the tally and returns its result" do
             subject.on(:ok) do |pending_message|
               expect(pending_message.status).to eq("enqueued")

--- a/decidim-bulletin_board-ruby/spec/decidim/bulletin_board/authority/start_vote_spec.rb
+++ b/decidim-bulletin_board-ruby/spec/decidim/bulletin_board/authority/start_vote_spec.rb
@@ -27,6 +27,10 @@ module Decidim
             expect { subject.call }.to broadcast(:ok)
           end
 
+          it "build the right message_id" do
+            expect(subject.message_id).to eq("decidim-test-authority.decidim-test-authority.1.start_vote+a.decidim-test-authority")
+          end
+
           it "uses the graphql client to start the voting period and returns its result" do
             subject.on(:ok) do |pending_message|
               expect(pending_message.status).to eq("enqueued")

--- a/decidim-bulletin_board-ruby/spec/decidim/bulletin_board/client_spec.rb
+++ b/decidim-bulletin_board-ruby/spec/decidim/bulletin_board/client_spec.rb
@@ -41,22 +41,23 @@ module Decidim
       describe "start_key_ceremony" do
         subject { instance.start_key_ceremony(election_id) }
 
+        before do
+          stub_command("Decidim::BulletinBoard::Authority::StartKeyCeremony", :call, *result)
+        end
+
         let(:election_id) { "test.1" }
+        let(:result) { [:ok, double(status: "enqueued")] }
 
-        context "when everything went ok" do
-          before do
-            stub_wisper_publisher("Decidim::BulletinBoard::Authority::StartKeyCeremony", :call, :ok, double(status: "enqueued"))
-          end
+        it "yields the message_id" do
+          expect {|block| instance.start_key_ceremony(election_id, &block) } .to yield_with_args("a.message+id")
+        end
 
-          it "calls the StartKeyCeremony command and returns the result" do
-            expect(subject.status).to eq("enqueued")
-          end
+        it "calls the StartKeyCeremony command and returns the result" do
+          expect(subject.status).to eq("enqueued")
         end
 
         context "when something went wrong" do
-          before do
-            stub_wisper_publisher("Decidim::BulletinBoard::Authority::StartKeyCeremony", :call, :error, "something went wrong")
-          end
+          let(:result) { [:error, "something went wrong"] }
 
           it "calls the StartKeyCeremony command and throws an error" do
             expect { subject }.to raise_error("something went wrong")
@@ -67,22 +68,23 @@ module Decidim
       describe "start_vote" do
         subject { instance.start_vote(election_id) }
 
+        before do
+          stub_command("Decidim::BulletinBoard::Authority::StartVote", :call, *result)
+        end
+
         let(:election_id) { "test.1" }
+        let(:result) { [:ok, double(status: "enqueued")] }
 
-        context "when everything went ok" do
-          before do
-            stub_wisper_publisher("Decidim::BulletinBoard::Authority::StartVote", :call, :ok, double(status: "enqueued"))
-          end
+        it "yields the message_id" do
+          expect {|block| instance.start_vote(election_id, &block) } .to yield_with_args("a.message+id")
+        end
 
-          it "calls the StartVote command and return the result" do
-            expect(subject.status).to eq("enqueued")
-          end
+        it "calls the StartVote command and return the result" do
+          expect(subject.status).to eq("enqueued")
         end
 
         context "when something went wrong" do
-          before do
-            stub_wisper_publisher("Decidim::BulletinBoard::Authority::StartVote", :call, :error, "something went wrong")
-          end
+          let(:result) { [:error, "something went wrong"] }
 
           it "calls the StartVote command and throws an error" do
             expect { subject }.to raise_error("something went wrong")
@@ -90,41 +92,30 @@ module Decidim
         end
       end
 
-      describe "cast_vote_message_id" do
-        let(:election_id) { "test.1" }
-        let(:voter_id) { "voter.1" }
-
-        context "when everything went ok" do
-          it "calls the cast_vote_message_id method and returns message_id" do
-            message_id = subject.cast_vote_message_id(election_id, voter_id)
-            expect(message_id).to eq("decidim-test-authority.test.1.vote.cast+v.voter.1")
-          end
-        end
-      end
-
       describe "cast_vote" do
         subject { instance.cast_vote(election_id, voter_id, encrypted_vote) }
+
+        before do
+          stub_command("Decidim::BulletinBoard::Voter::CastVote", :call, *result)
+        end
 
         let(:election_id) { "test.1" }
         let(:voter_id) { "voter.1" }
         let(:encrypted_vote) do
           { question_1: "aNsWeR 1" }.to_json
         end
+        let(:result) { [:ok, double(status: "enqueued")] }
 
-        context "when everything went ok" do
-          before do
-            stub_wisper_publisher("Decidim::BulletinBoard::Voter::CastVote", :call, :ok, double(status: "enqueued"))
-          end
+        it "yields the message_id" do
+          expect {|block| instance.cast_vote(election_id, voter_id, encrypted_vote, &block) } .to yield_with_args("a.message+id")
+        end
 
-          it "calls the CastVote command and return the result" do
-            expect(subject.status).to eq("enqueued")
-          end
+        it "calls the CastVote command and return the result" do
+          expect(subject.status).to eq("enqueued")
         end
 
         context "when something went wrong" do
-          before do
-            stub_wisper_publisher("Decidim::BulletinBoard::Voter::CastVote", :call, :error, "something went wrong")
-          end
+          let(:result) { [:error, "something went wrong"] }
 
           it "calls the CastVote command and throws an error" do
             expect { subject }.to raise_error("something went wrong")
@@ -135,22 +126,19 @@ module Decidim
       describe "end_vote" do
         subject { instance.end_vote(election_id) }
 
+        before do
+          stub_command("Decidim::BulletinBoard::Authority::EndVote", :call, *result)
+        end
+
         let(:election_id) { "test.1" }
+        let(:result) { [:ok, double(status: "enqueued")] }
 
-        context "when everything went ok" do
-          before do
-            stub_wisper_publisher("Decidim::BulletinBoard::Authority::EndVote", :call, :ok, double(status: "enqueued"))
-          end
-
-          it "calls the EndVote command and returns the result" do
-            expect(subject.status).to eq("enqueued")
-          end
+        it "calls the EndVote command and returns the result" do
+          expect(subject.status).to eq("enqueued")
         end
 
         context "when something went wrong" do
-          before do
-            stub_wisper_publisher("Decidim::BulletinBoard::Authority::EndVote", :call, :error, "something went wrong")
-          end
+          let(:result) { [:error, "something went wrong"] }
 
           it "calls the EndVote command and throws an error" do
             expect { subject }.to raise_error("something went wrong")
@@ -212,22 +200,23 @@ module Decidim
       describe "start_tally" do
         subject { instance.start_tally(election_id) }
 
+        before do
+          stub_command("Decidim::BulletinBoard::Authority::StartTally", :call, *result)
+        end
+
         let(:election_id) { "test.1" }
+        let(:result) { [:ok, double(status: "enqueued")] }
 
-        context "when everything went ok" do
-          before do
-            stub_wisper_publisher("Decidim::BulletinBoard::Authority::StartTally", :call, :ok, double(status: "enqueued"))
-          end
+        it "yields the message_id" do
+          expect {|block| instance.start_tally(election_id, &block) } .to yield_with_args("a.message+id")
+        end
 
-          it "calls the StartTally command and returns the result" do
-            expect(subject.status).to eq("enqueued")
-          end
+        it "calls the StartTally command and returns the result" do
+          expect(subject.status).to eq("enqueued")
         end
 
         context "when something went wrong" do
-          before do
-            stub_wisper_publisher("Decidim::BulletinBoard::Authority::StartTally", :call, :error, "something went wrong")
-          end
+          let(:result) { [:error, "something went wrong"] }
 
           it "calls the StartTally command and throws an error" do
             expect { subject }.to raise_error("something went wrong")
@@ -238,22 +227,23 @@ module Decidim
       describe "publish_results" do
         subject { instance.publish_results(election_id) }
 
+        before do
+          stub_command("Decidim::BulletinBoard::Authority::PublishResults", :call, *result)
+        end
+
         let(:election_id) { "decidim-test-authority.1" }
+        let(:result) { [:ok, "results_published"] }
 
-        context "when everything went ok" do
-          before do
-            stub_wisper_publisher("Decidim::BulletinBoard::Authority::PublishResults", :call, :ok, "results_published")
-          end
+        it "yields the message_id" do
+          expect {|block| instance.publish_results(election_id, &block) } .to yield_with_args("a.message+id")
+        end
 
-          it "calls the PublishResults command and returns the result" do
-            expect(subject).to eq("results_published")
-          end
+        it "calls the PublishResults command and returns the result" do
+          expect(subject).to eq("results_published")
         end
 
         context "when something went wrong" do
-          before do
-            stub_wisper_publisher("Decidim::BulletinBoard::Authority::PublishResults", :call, :error, "Sorry, something went wrong")
-          end
+          let(:result) { [:error, "Sorry, something went wrong"] }
 
           it "calls the PublishResults command and throws an error" do
             expect { subject }.to raise_error("Sorry, something went wrong")

--- a/decidim-bulletin_board-ruby/spec/decidim/bulletin_board/client_spec.rb
+++ b/decidim-bulletin_board-ruby/spec/decidim/bulletin_board/client_spec.rb
@@ -49,7 +49,7 @@ module Decidim
         let(:result) { [:ok, double(status: "enqueued")] }
 
         it "yields the message_id" do
-          expect {|block| instance.start_key_ceremony(election_id, &block) } .to yield_with_args("a.message+id")
+          expect { |block| instance.start_key_ceremony(election_id, &block) }.to yield_with_args("a.message+id")
         end
 
         it "calls the StartKeyCeremony command and returns the result" do
@@ -76,7 +76,7 @@ module Decidim
         let(:result) { [:ok, double(status: "enqueued")] }
 
         it "yields the message_id" do
-          expect {|block| instance.start_vote(election_id, &block) } .to yield_with_args("a.message+id")
+          expect { |block| instance.start_vote(election_id, &block) }.to yield_with_args("a.message+id")
         end
 
         it "calls the StartVote command and return the result" do
@@ -107,7 +107,7 @@ module Decidim
         let(:result) { [:ok, double(status: "enqueued")] }
 
         it "yields the message_id" do
-          expect {|block| instance.cast_vote(election_id, voter_id, encrypted_vote, &block) } .to yield_with_args("a.message+id")
+          expect { |block| instance.cast_vote(election_id, voter_id, encrypted_vote, &block) }.to yield_with_args("a.message+id")
         end
 
         it "calls the CastVote command and return the result" do
@@ -208,7 +208,7 @@ module Decidim
         let(:result) { [:ok, double(status: "enqueued")] }
 
         it "yields the message_id" do
-          expect {|block| instance.start_tally(election_id, &block) } .to yield_with_args("a.message+id")
+          expect { |block| instance.start_tally(election_id, &block) }.to yield_with_args("a.message+id")
         end
 
         it "calls the StartTally command and returns the result" do
@@ -235,7 +235,7 @@ module Decidim
         let(:result) { [:ok, "results_published"] }
 
         it "yields the message_id" do
-          expect {|block| instance.publish_results(election_id, &block) } .to yield_with_args("a.message+id")
+          expect { |block| instance.publish_results(election_id, &block) }.to yield_with_args("a.message+id")
         end
 
         it "calls the PublishResults command and returns the result" do

--- a/decidim-bulletin_board-ruby/spec/decidim/bulletin_board/command_spec.rb
+++ b/decidim-bulletin_board-ruby/spec/decidim/bulletin_board/command_spec.rb
@@ -10,8 +10,8 @@ module Decidim
 
       include_context "with a configured bulletin board"
 
-      describe ".message_id" do
-        subject { instance.message_id(unique_election_id, type_subtype, voter_id) }
+      describe ".build_message_id" do
+        subject { instance.build_message_id(unique_election_id, type_subtype, voter_id) }
 
         let(:unique_election_id) { "decidim-test-authority.26" }
         let(:type_subtype) { "vote.cast" }

--- a/decidim-bulletin_board-ruby/spec/decidim/bulletin_board/voter/cast_vote_spec.rb
+++ b/decidim-bulletin_board-ruby/spec/decidim/bulletin_board/voter/cast_vote_spec.rb
@@ -29,6 +29,10 @@ module Decidim
             expect { subject.call }.to broadcast(:ok)
           end
 
+          it "build the right message_id" do
+            expect(subject.message_id).to eq("decidim-test-authority.1.vote.cast+v.asdasdafdsaasdq")
+          end
+
           it "uses the graphql client to perform a Vote mutation and return its result" do
             subject.on(:ok) do |pending_message|
               expect(pending_message.status).to eq("enqueued")

--- a/decidim-bulletin_board-ruby/spec/spec_helper.rb
+++ b/decidim-bulletin_board-ruby/spec/spec_helper.rb
@@ -7,6 +7,7 @@ require "byebug"
 require "webmock/rspec"
 require "wisper/rspec/matchers"
 
+require "support/command_stub"
 require "shared/client_context"
 
 RSpec.configure do |config|

--- a/decidim-bulletin_board-ruby/spec/support/command_stub.rb
+++ b/decidim-bulletin_board-ruby/spec/support/command_stub.rb
@@ -2,7 +2,7 @@
 
 def stub_command(clazz, called_method, event_to_publish, *published_event_args)
   stub_const(clazz, Class.new(TestWisperPublisher) do
-    define_method(called_method) do |*args|
+    define_method(called_method) do |*_args|
       publish(event_to_publish, *published_event_args)
     end
 

--- a/decidim-bulletin_board-ruby/spec/support/command_stub.rb
+++ b/decidim-bulletin_board-ruby/spec/support/command_stub.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+def stub_command(clazz, called_method, event_to_publish, *published_event_args)
+  stub_const(clazz, Class.new(TestWisperPublisher) do
+    define_method(called_method) do |*args|
+      publish(event_to_publish, *published_event_args)
+    end
+
+    define_method(:message_id) do
+      "a.message+id"
+    end
+  end)
+end


### PR DESCRIPTION
This PR generalize two things done in the `cast_vote` to use them on the admin side:
* Ruby: Most of the client operations yield the `message_id` before sending the command to the BB server.
* JS: The method to wait for a pending message to be processed was moved from the `Voter` class to the `Client`, to use it in the admin zone too.