### PR TITLE
chore: update decidim-bulletin_board to 0.9.0

### DIFF
--- a/decidim-bulletin_board-app/Gemfile
+++ b/decidim-bulletin_board-app/Gemfile
@@ -43,7 +43,7 @@ gem "sprockets-es6"
 
 gem "factory_bot_rails"
 
-gem "decidim-bulletin_board", "~> 0.8.0"
+gem "decidim-bulletin_board", "~> 0.9.0"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/decidim-bulletin_board-app/Gemfile.lock
+++ b/decidim-bulletin_board-app/Gemfile.lock
@@ -81,7 +81,7 @@ GEM
     database_cleaner-active_record (1.8.0)
       activerecord
       database_cleaner (~> 1.8.0)
-    decidim-bulletin_board (0.8.2)
+    decidim-bulletin_board (0.9.0)
       byebug (~> 11.0)
       graphlient (~> 0.4.0)
       jwt (~> 2.2.2)
@@ -323,7 +323,7 @@ DEPENDENCIES
   byebug
   cypress-on-rails (~> 1.0)
   database_cleaner-active_record
-  decidim-bulletin_board (~> 0.8.0)
+  decidim-bulletin_board (~> 0.9.0)
   factory_bot_rails
   faker (~> 1.9)
   graphiql-rails


### PR DESCRIPTION
Updates the `decidim-bulletin_board` to the `0.9.0` version.