### PR TITLE
Fix BulletinBoard version and graphiql path in `api/docs`

### DIFF
--- a/decidim-bulletin_board-app/app/views/documentation/show.html.erb
+++ b/decidim-bulletin_board-app/app/views/documentation/show.html.erb
@@ -1,10 +1,10 @@
 
 <div class="intro">
-  <div class="version">Bulletin Board Version 1.0s</div>
+  <div class="version">Bulletin Board Version <%= Decidim::BulletinBoard::VERSION %></div>
 
   <h1>Bulletin Board Version API documentation</h1>
-  <% if defined?(graphiql_path) %>
-    <%= link_to "Explore the API interactively with GraphiQL", graphiql_path %>
+  <% if defined?(graphiql_rails) %>
+    <%= link_to "Explore the API interactively with GraphiQL", graphiql_rails_path %>
   <% end %>
 </div>
 


### PR DESCRIPTION
This PR fixes the BB version showed in the `api/docs` page, it also fixes the path to `graphiql`.

<img width="657" alt="Screenshot 2021-02-02 at 10 52 30" src="https://user-images.githubusercontent.com/210216/106584750-dde7bc80-6546-11eb-85a7-0816bcf200f8.png">



