### PR TITLE
Cleanup the install_eg_wrappers.sh script

### DIFF
--- a/decidim-bulletin_board-app/install_eg_wrappers.sh
+++ b/decidim-bulletin_board-app/install_eg_wrappers.sh
@@ -1,12 +1,18 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# Install ElectionGuard dependencies
-sudo apt-get install -y libgmp-dev libmpfr-dev libmpc-dev
+set -e
 
-# Update pip
+echo "Installing ElectionGuard dependencies"
+sudo apt-get install -y libgmp-dev libmpfr-dev libmpc-dev libffi-dev
+
+echo "Update Pip"
 python3 -m pip install cryptography==3.2.1
 
-# Install Decidim ElectionGuard wrappers (temporarily from the repository)
-rm -rf ../../decidim-electionguard
-git clone https://github.com/decidim/decidim-electionguard.git ../../decidim-electionguard
-cd ../../decidim-electionguard && python3 setup.py install
+echo "Install Decidim ElectionGuard wrappers (temporarily from the repository)"
+if [ -d /tmp/decidim-electionguard ] ; then
+  rm -rf /tmp/decidim-electionguard
+fi
+
+git clone https://github.com/decidim/decidim-electionguard.git /tmp/decidim-electionguard
+cd /tmp/decidim-electionguard
+python3 setup.py install


### PR DESCRIPTION
Improves the install ElectionGuard wrapper script with: 

* Better portability with /usr/bin/env shebang 
* -e for "Exit immediately if a command exits with a non-zero status."
* I had an error with my python3 installation (_ctypes module). I could solve it with the `libffi-dev` apt package
* Instead of using relative routes (../../) use /tmp/ folder
* Checks existence of the repository before removing it
* Change commets to echo to give more feedback to users 
