### PR TITLE
Fix dummy schema results calculations & other fixes

### DIFF
--- a/decidim-bulletin_board-app/app/commands/enqueue_message.rb
+++ b/decidim-bulletin_board-app/app/commands/enqueue_message.rb
@@ -44,7 +44,7 @@ class EnqueueMessage < Rectify::Command
   end
 
   def pending_messages?
-    PendingMessage.enqueued.exists?(client: client, election: election)
+    PendingMessage.enqueued.exists?(client: client, election: election, message_id: message_id)
   end
 
   def create_pending_message!

--- a/decidim-bulletin_board-app/app/graphql/types/log_entry_type.rb
+++ b/decidim-bulletin_board-app/app/graphql/types/log_entry_type.rb
@@ -6,5 +6,6 @@ module Types
 
     field :chained_hash, String, null: false
     field :content_hash, String, null: true
+    field :decoded_data, GraphQL::Types::JSON, null: false
   end
 end

--- a/decidim-bulletin_board-app/app/services/voting_scheme/dummy.rb
+++ b/decidim-bulletin_board-app/app/services/voting_scheme/dummy.rb
@@ -122,7 +122,7 @@ module VotingScheme
       results = build_questions_struct(0)
       state[:joint_shares].each do |question, answers|
         answers.each do |answer, joint_share|
-          results[question][answer] = (joint_share / state[:joint_election_key])**(1.0 / state[:trustees].count).round
+          results[question][answer] = ((joint_share / state[:joint_election_key])**(1.0 / state[:trustees].count)).round
         end
       end
 

--- a/decidim-bulletin_board-app/db/seeds.rb
+++ b/decidim-bulletin_board-app/db/seeds.rb
@@ -13,12 +13,13 @@ def create_start_key_ceremony_log_entry(election)
 end
 
 def create_key_ceremony_log_entries(election)
-  Trustee.first(3).zip(Test::PrivateKeys.trustees_private_keys).each do |trustee, private_key|
+  Trustee.first(3).zip(Test::PrivateKeys.trustees_private_keys, Test::Elections.trustees_election_keys).each do |trustee, private_key, election_key|
     FactoryBot.create(:log_entry,
                       election: election,
                       client: trustee,
                       private_key: private_key,
                       message: FactoryBot.build(:key_ceremony_message,
+                                                election_public_key: election_key,
                                                 election: election,
                                                 trustee: trustee))
   end
@@ -41,10 +42,9 @@ end
 
 def create_vote_log_entries(election, amount = 3)
   amount.times do
-    FactoryBot.create(:log_entry,
-                      election: election,
-                      message: FactoryBot.build(:vote_message,
-                                                election: election))
+    vote_message = FactoryBot.build(:vote_message, election: election)
+    FactoryBot.create(:pending_message, :accepted, election: election, message: vote_message)
+    FactoryBot.create(:log_entry, election: election, message: vote_message)
   end
 end
 
@@ -61,18 +61,20 @@ def create_start_tally_log_entries(election)
                     message: FactoryBot.build(:start_tally_message,
                                               election: election))
   FactoryBot.create(:log_entry,
+                    :by_bulletin_board,
                     election: election,
                     message: FactoryBot.build(:tally_cast_message,
                                               election: election))
 end
 
 def create_tally_log_entries(election)
-  Trustee.first(3).zip(Test::PrivateKeys.trustees_private_keys).each do |trustee, private_key|
+  Trustee.first(3).zip(Test::PrivateKeys.trustees_private_keys, Test::Elections.trustees_election_keys).each do |trustee, private_key, election_key|
     FactoryBot.create(:log_entry,
                       election: election,
                       client: trustee,
                       private_key: private_key,
                       message: FactoryBot.build(:tally_share_message,
+                                                election_public_key: election_key,
                                                 election: election,
                                                 trustee: trustee))
   end

--- a/decidim-bulletin_board-app/spec/factories/messages.rb
+++ b/decidim-bulletin_board-app/spec/factories/messages.rb
@@ -185,14 +185,6 @@ FactoryBot.define do
       trait :invalid do
         owner_id { "wrong_trustee" }
       end
-
-      trait :trustee_2 do
-        election_public_key { Test::Elections.trustees_election_keys.second }
-      end
-
-      trait :trustee_3 do
-        election_public_key { Test::Elections.trustees_election_keys.third }
-      end
     end
 
     factory :end_key_ceremony_message, parent: :message do
@@ -313,14 +305,6 @@ FactoryBot.define do
 
       trait :invalid do
         owner_id { "wrong_trustee" }
-      end
-
-      trait :trustee_2 do
-        election_public_key { Test::Elections.trustees_election_keys.second }
-      end
-
-      trait :trustee_3 do
-        election_public_key { Test::Elections.trustees_election_keys.third }
       end
 
       after(:build) do |content, evaluator|

--- a/decidim-bulletin_board-app/spec/factories/models.rb
+++ b/decidim-bulletin_board-app/spec/factories/models.rb
@@ -129,6 +129,7 @@ FactoryBot.define do
 
     trait :by_bulletin_board do
       bulletin_board { true }
+      client { nil }
       signed_data { BulletinBoard.sign(message) }
     end
   end

--- a/decidim-bulletin_board-js/src/types.d.ts
+++ b/decidim-bulletin_board-js/src/types.d.ts
@@ -60,6 +60,7 @@ export type LogEntry = MessageInterface & {
   chainedHash: Scalars['String'];
   client: Client;
   contentHash?: Maybe<Scalars['String']>;
+  decodedData: Scalars['JSON'];
   election: Election;
   id: Scalars['ID'];
   messageId: Scalars['String'];

--- a/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/graphql/bb_schema.json
+++ b/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/graphql/bb_schema.json
@@ -436,6 +436,24 @@
               "deprecationReason": null
             },
             {
+              "name": "decodedData",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "JSON",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "election",
               "description": null,
               "args": [


### PR DESCRIPTION
This PR implements some fixes to the BB app:
* It fixes the calculation of the results of an election with the dummy voting scheme.
* It allows to enqueue several pending messages for the same client, if they don't have the same `message_id`.
* It fixes the seeding process to use the right election keys for the trustees and to sign correctly the messages sent by the BB.
* It adds the `decodedData` field to the graphQL interface to ease the debugging of the messages.