### PR TITLE
Allow to create elections on the sandbox

### DIFF
--- a/decidim-bulletin_board-app/app/assets/stylesheets/api/docs.scss
+++ b/decidim-bulletin_board-app/app/assets/stylesheets/api/docs.scss
@@ -71,3 +71,7 @@ blockquote {
 table {
   width: 100%;
 }
+
+input[type="text"] {
+  width: 100%;
+}

--- a/decidim-bulletin_board-app/app/commands/create_election.rb
+++ b/decidim-bulletin_board-app/app/commands/create_election.rb
@@ -100,7 +100,7 @@ class CreateElection < Rectify::Command
     run_validations do
       if voting_scheme_class.blank?
         "A valid Voting Scheme must be specified"
-      elsif title.blank?
+      elsif title.none? || title.values.any?(&:blank?)
         "Missing title"
       elsif start_date.after?(end_date)
         "Starting date cannot be after the end date"

--- a/decidim-bulletin_board-app/app/commands/create_election.rb
+++ b/decidim-bulletin_board-app/app/commands/create_election.rb
@@ -75,7 +75,9 @@ class CreateElection < Rectify::Command
   end
 
   def title
-    @title ||= decoded_data.dig(:description, :name, :text, 0, :value)
+    @title ||= decoded_data.dig(:description, :name, :text).map do |text|
+      [text["language"], text["value"]]
+    end.to_h
   end
 
   def start_date

--- a/decidim-bulletin_board-app/app/graphql/decidim_bulletin_board_schema.rb
+++ b/decidim-bulletin_board-app/app/graphql/decidim_bulletin_board_schema.rb
@@ -3,14 +3,4 @@
 class DecidimBulletinBoardSchema < GraphQL::Schema
   mutation(Types::MutationType)
   query(Types::QueryType)
-
-  # Opt in to the new runtime (default in future graphql-ruby versions)
-  use GraphQL::Execution::Interpreter
-  use GraphQL::Analysis::AST
-
-  # Add built-in connections for pagination
-  use GraphQL::Pagination::Connections
-
-  # Add ActionCable adapter
-  use GraphQL::Subscriptions::ActionCableSubscriptions
 end

--- a/decidim-bulletin_board-app/app/graphql/types/election_type.rb
+++ b/decidim-bulletin_board-app/app/graphql/types/election_type.rb
@@ -3,7 +3,7 @@
 module Types
   class ElectionType < Types::BaseObject
     field :id, ID, null: false, method: :unique_id
-    field :title, String, null: false
+    field :title, GraphQL::Types::JSON, null: false
     field :status, String, null: false
     field :authority, Types::ClientType, null: false
     field :trustees, [Types::ClientType], null: false, description: "Returns the list of trustees for this election"

--- a/decidim-bulletin_board-app/app/views/sandbox/elections/index.html.erb
+++ b/decidim-bulletin_board-app/app/views/sandbox/elections/index.html.erb
@@ -20,7 +20,7 @@
       <% elections.each do |election| %>
         <tr>
           <td><%= election.unique_id %></td>
-          <td><%= election.title %></td>
+          <td><%= election.title.values.first %></td>
           <td><%= election.status %></td>
           <td>
             <% if election.created? %>
@@ -50,4 +50,6 @@
       <% end %>
     </tbody>
   </table>
+
+  <%= link_to "Setup new election", new_sandbox_election_path %>
 </div>

--- a/decidim-bulletin_board-app/app/views/sandbox/elections/key_ceremony.html.erb
+++ b/decidim-bulletin_board-app/app/views/sandbox/elections/key_ceremony.html.erb
@@ -2,7 +2,7 @@
 <div class="intro">
   <div class="version">Bulletin Board Version <%= Decidim::BulletinBoard::VERSION %></div>
 
-  <h1>Key ceremony for <%= election.title %></h1>
+  <h1>Key ceremony for <%= election.title.values.first %></h1>
 </div>
 
 <div class="info">

--- a/decidim-bulletin_board-app/app/views/sandbox/elections/new.html.erb
+++ b/decidim-bulletin_board-app/app/views/sandbox/elections/new.html.erb
@@ -1,0 +1,79 @@
+<div class="intro">
+  <div class="version">Bulletin Board Version <%= Decidim::BulletinBoard::VERSION %></div>
+
+  <h1>Create election</h1>
+</div>
+
+<div class="info">
+  <%= link_to "Back", sandbox_elections_path %>
+
+  <form method="post" action="<%= sandbox_elections_path %>">
+    <%= hidden_field_tag :authenticity_token, form_authenticity_token -%>
+    <ul>
+      <li><label>Election ID: <input name="election[id]" type="text" value="<%= SecureRandom.base58 %>"></label></li>
+      <li><label>Default locale: <select name="election[default_locale]"><option>ca</option><option selected>en</option><option>es</option></select></label></li>
+      <li>
+        <label>Title:
+          <input name="election[title][ca]" type="text" value="Votació de prova" placeholder="ca">
+          <input name="election[title][en]" type="text" value="Test election" placeholder="en">
+          <input name="election[title][es]" type="text" value="Votación de prueba" placeholder="es">
+        </label>
+      </li>
+      <li><label>Start date: <input name="election[start_date]" type="number" value="1"> days from now</label></li>
+      <li><label>End date: <input name="election[end_date]" type="number" value="1"> after the start</label></li>
+      <li>
+        <h2>Questions</h2>
+        <ul>
+        <% 3.times.each_with_index do |question_index| %>
+          <li><h3>Question #<%= question_index + 1 %></h3></li>
+          <li>
+              <label>Title:
+                <input name="election[questions][<%= question_index %>][title][ca]" type="text" value="Pregunta #<%= question_index + 1 %>" placeholder="ca">
+                <input name="election[questions][<%= question_index %>][title][en]" type="text" value="Question #<%= question_index + 1 %>" placeholder="en">
+                <input name="election[questions][<%= question_index %>][title][es]" type="text" value="Pregunta #<%= question_index + 1 %>" placeholder="es">
+              </label>
+          </li>
+          <li>
+              <label>Description:
+                <input name="election[questions][<%= question_index %>][description][ca]" type="text" value="Descripció #<%= question_index + 1 %>" placeholder="ca">
+                <input name="election[questions][<%= question_index %>][description][en]" type="text" value="Description #<%= question_index + 1 %>" placeholder="en">
+                <input name="election[questions][<%= question_index %>][description][es]" type="text" value="Descripción #<%= question_index + 1 %>" placeholder="es">
+              </label>
+          </li>
+          <li>
+              <label>Slug: <input name="election[questions][<%= question_index %>][slug]" type="text" value="question-<%= question_index + 1 %>"></label>
+          </li>
+          <li>
+              <label>Weight: <input name="election[questions][<%= question_index %>][weight]" type="number" value="0"></label>
+          </li>
+          <li>
+              <label>Maximum selections: <input name="election[questions][<%= question_index %>][max_selections]" type="number" value="1" min="1" max="4"></label>
+          </li>
+          <li>
+              <h4>Answers: </h4>
+              <ul>
+                <% 3.times.each_with_index do |answer_index| %>
+                <li><h5>Answer #<%= question_index + 1 %>.<%= answer_index + 1 %></h5></li>
+                <li>
+                    <label>Title:
+                      <input name="election[questions][<%= question_index %>][answers][<%= answer_index %>][title][ca]" type="text" value="Resposta #<%= question_index + 1 %>.<%= answer_index + 1 %>" placeholder="ca">
+                      <input name="election[questions][<%= question_index %>][answers][<%= answer_index %>][title][en]" type="text" value="Answer #<%= question_index + 1 %>.<%= answer_index + 1 %>" placeholder="en">
+                      <input name="election[questions][<%= question_index %>][answers][<%= answer_index %>][title][es]" type="text" value="Respuesta #<%= question_index + 1 %>.<%= answer_index + 1 %>" placeholder="es">
+                    </label>
+                </li>
+                <li>
+                    <label>Slug: <input name="election[questions][<%= question_index %>][answers][<%= answer_index %>][slug]" type="text" value="answer-<%= question_index + 1 %>-<%= answer_index + 1 %>"></label>
+                </li>
+                <li>
+                    <label>Weight: <input name="election[questions][<%= question_index %>][answers][<%= answer_index %>][weight]" type="number" value="0"></label>
+                </li>
+                <% end %>
+              </ul>
+          </li>
+        <% end %>
+        </ul>
+      </li>
+      <li><input type="submit"></li>
+    </ul>
+  </form>
+</div>

--- a/decidim-bulletin_board-app/app/views/sandbox/elections/tally.html.erb
+++ b/decidim-bulletin_board-app/app/views/sandbox/elections/tally.html.erb
@@ -3,7 +3,7 @@
 <div class="intro">
   <div class="version">Bulletin Board Version <%= Decidim::BulletinBoard::VERSION %></div>
 
-  <h1>Tally for <%= election.title %></h1>
+  <h1>Tally for <%= election.title.values.first %></h1>
 </div>
 
 <div class="info">

--- a/decidim-bulletin_board-app/app/views/sandbox/elections/vote.html.erb
+++ b/decidim-bulletin_board-app/app/views/sandbox/elections/vote.html.erb
@@ -3,7 +3,7 @@
 <div class="intro">
   <div class="version">Bulletin Board Version <%= Decidim::BulletinBoard::VERSION %></div>
 
-  <h1>Vote for <%= election.title %></h1>
+  <h1>Vote for <%= election.title.values.first %></h1>
 </div>
 
 <div class="info">

--- a/decidim-bulletin_board-app/config/routes.rb
+++ b/decidim-bulletin_board-app/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
 
   if Rails.env.development? || Rails.env.test?
     scope "/sandbox", module: :sandbox, as: :sandbox do
-      resources :elections, only: [:index] do
+      resources :elections, only: [:new, :create, :index] do
         member do
           get :start_key_ceremony
           get :key_ceremony

--- a/decidim-bulletin_board-app/db/migrate/20210211173543_change_elections_title_type.rb
+++ b/decidim-bulletin_board-app/db/migrate/20210211173543_change_elections_title_type.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ChangeElectionsTitleType < ActiveRecord::Migration[6.0]
+  def change
+    change_column :elections, :title, "jsonb USING title::jsonb"
+  end
+end

--- a/decidim-bulletin_board-app/db/schema.rb
+++ b/decidim-bulletin_board-app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_18_165807) do
+ActiveRecord::Schema.define(version: 2021_02_11_173543) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -42,7 +42,7 @@ ActiveRecord::Schema.define(version: 2021_01_18_165807) do
 
   create_table "elections", force: :cascade do |t|
     t.bigint "authority_id", null: false
-    t.string "title", null: false
+    t.jsonb "title", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "unique_id", null: false

--- a/decidim-bulletin_board-app/spec/factories/models.rb
+++ b/decidim-bulletin_board-app/spec/factories/models.rb
@@ -33,7 +33,7 @@ FactoryBot.define do
       election_id { generate(:election_id) }
     end
 
-    title { Faker::Name.name }
+    title { { en: Faker::Name.name } }
     authority { Authority.first }
     status { :created }
     unique_id { [authority.unique_id, election_id].join(".") }

--- a/decidim-bulletin_board-app/spec/mutations/create_election_mutation_spec.rb
+++ b/decidim-bulletin_board-app/spec/mutations/create_election_mutation_spec.rb
@@ -42,7 +42,7 @@ module Mutations
         election: {
           id: be_present,
           status: "created",
-          title: payload[:description][:name][:text][0][:value],
+          title: payload[:description][:name][:text].map { |title| [title[:language].to_sym, title[:value]] }.to_h,
           authority: {
             id: authority.unique_id
           }

--- a/decidim-bulletin_board-js/src/types.d.ts
+++ b/decidim-bulletin_board-js/src/types.d.ts
@@ -36,7 +36,7 @@ export type Election = {
   /** Returns the list of log entries for this election in the bulletin board */
   logEntries: Array<LogEntry>;
   status: Scalars['String'];
-  title: Scalars['String'];
+  title: Scalars['JSON'];
   /** Returns the list of trustees for this election */
   trustees: Array<Client>;
 };

--- a/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/graphql/bb_schema.json
+++ b/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/graphql/bb_schema.json
@@ -278,7 +278,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "String",
+                  "name": "JSON",
                   "ofType": null
                 }
               },


### PR DESCRIPTION
This PR adds the `create_election` command to be tested in the sandbox. It also changes the election title field to a `jsonb` column to be able to store different translations for that text. 