### PR TITLE
Get ballot hash before auditing or casting

### DIFF
--- a/decidim-bulletin_board-app/app/javascript/decidim-bulletin_board/voter/voter.js
+++ b/decidim-bulletin_board-app/app/javascript/decidim-bulletin_board/voter/voter.js
@@ -66,16 +66,22 @@ export class Voter {
    * @returns {Promise<Object>} - The data encrypted.
    */
   encrypt(plainVote) {
-    return this.wrapperAdapter.encrypt(plainVote);
+    const ballot = this.wrapperAdapter.encrypt(plainVote);
+    const ballotHash = this.generateBallotHash(ballot);
+
+    return {
+      ballot,
+      ballotHash,
+    };
   }
 
   /**
-   * Encrypts the data using the wrapper.
+   * Generates the ballot hash from the excrpyted vote
    *
    * @param {Object} encryptedVote - The encryptedVote to be encrypted.
-   * @returns {Promise<Object>} - The data encrypted and its hash.
+   * @returns {Promise<Object>} - The data encrypted and its hashThe ballot hash.
    */
-  async encryptBallot(encryptedVote) {
+  async generateBallotHash(encryptedVote) {
     const encryptedBallot = encryptedVote.encryptedBallot;
     return window.crypto.subtle
       .digest("SHA-256", new TextEncoder().encode(encryptedBallot))
@@ -85,30 +91,8 @@ export class Voter {
           .map((b) => b.toString(16).padStart(2, "0"))
           .join("");
 
-        return {
-          encryptedBallot,
-          encryptedBallotHash,
-        };
+        return encryptedBallotHash;
       });
-  }
-
-  /**
-   * Audits the data using the wrapper.
-   *
-   * @param {Object} encryptedVote - The encrypted vote to be audited.
-   * @returns {Promise<Object>} - The encrypted ballot, the vote hash and the plain vote.
-   */
-  async auditBallot(encryptedVote) {
-    const auditableBallot = encryptedVote.auditableBallot;
-    const ballot = await this.encryptBallot(encryptedVote);
-    const encryptedBallot = ballot.encryptedBallot;
-    const encryptedBallotHash = ballot.encryptedBallotHash;
-
-    return {
-      encryptedBallot,
-      encryptedBallotHash,
-      plainVote: auditableBallot,
-    };
   }
 
   /**

--- a/decidim-bulletin_board-app/app/javascript/decidim-bulletin_board/voter/voter.js
+++ b/decidim-bulletin_board-app/app/javascript/decidim-bulletin_board/voter/voter.js
@@ -65,9 +65,9 @@ export class Voter {
    *
    * @returns {Promise<Object>} - The data encrypted.
    */
-  encrypt(plainVote) {
-    const ballot = this.wrapperAdapter.encrypt(plainVote);
-    const ballotHash = this.generateBallotHash(ballot);
+  async encrypt(plainVote) {
+    const ballot = await this.wrapperAdapter.encrypt(plainVote);
+    const ballotHash = await this.generateBallotHash(ballot);
 
     return {
       ballot,

--- a/decidim-bulletin_board-app/app/javascript/packs/sandbox/vote.js
+++ b/decidim-bulletin_board-app/app/javascript/packs/sandbox/vote.js
@@ -12,6 +12,7 @@ $(async () => {
   const $voterId = $voter.find("input");
   const $doneMessage = $voter.find(".done-message");
   const $auditMessage = $voter.find(".audit-done-message");
+  const $ballotHash = $voter.find(".ballot-hash");
 
   $vote.on("change", (event) => {
     $vote.css("border", "");
@@ -69,18 +70,21 @@ $(async () => {
         invalidVoteFn();
       }
     },
-    castOrAuditBallot() {
+    castOrAuditBallot(encryptedBallot) {
+      $ballotHash.text(
+        `Your ballot identifier is: ${encryptedBallot.ballotHash}`
+      );
       $encryptVote.prop("disabled", true);
       $castVote.show();
       $auditVote.show();
     },
-    onAuditVote(onEventTriggered) {
+    onBindAuditBallotButton(onEventTriggered) {
       $auditVote.on("click", onEventTriggered);
     },
-    onVoteValidation(onEventTriggered) {
+    onBindCastBallotButton(onEventTriggered) {
       $castVote.on("click", onEventTriggered);
     },
-    onVoteAudition(auditedVote, auditFileName) {
+    onAuditBallot(auditedVote, auditFileName) {
       const vote = JSON.stringify(auditedVote);
       const link = document.createElement("a");
 
@@ -97,7 +101,7 @@ $(async () => {
       $auditMessage.show();
       $vote.css("background", "green");
     },
-    onVoteEncrypted({ encryptedBallot }) {
+    onCastBallot({ encryptedBallot }) {
       return $.ajax({
         method: "POST",
         contentType: "application/json",
@@ -110,7 +114,7 @@ $(async () => {
         },
       });
     },
-    onComplete() {
+    onCastComplete() {
       $castVote.prop("disabled", true);
       $auditVote.prop("disabled", true);
       $doneMessage.show();

--- a/decidim-bulletin_board-app/app/views/sandbox/elections/vote.html.erb
+++ b/decidim-bulletin_board-app/app/views/sandbox/elections/vote.html.erb
@@ -21,6 +21,7 @@
     </p>
 
     <p><button class="encrypt-vote" disabled>Encrypt vote</button></p>
+    <p class="ballot-hash"></p>
     <p>
       <button class="audit-vote">Audit vote</button>
       <button class="cast-vote">Cast vote</button>

--- a/decidim-bulletin_board-app/cypress/integration/sandbox/election.page.js
+++ b/decidim-bulletin_board-app/cypress/integration/sandbox/election.page.js
@@ -141,13 +141,31 @@ export class ElectionPage {
   }
 
   /**
+   * Encrypt a vote.
+   *
+   * @returns {undefined}
+   */
+  encryptVote() {
+    cy.findByText("Vote").click();
+    cy.findByText("Encrypt vote").should("be.visible").click();
+  }
+
+  /**
+   * Assert that the ballot hash is present
+   *
+   * @returns {undefined}
+   */
+  assertBallotHashIsPresent() {
+    cy.findByText("Encrypt vote").should("be.disabled");
+    cy.get(".ballot-hash").should("include.text", "Your ballot identifier is:");
+  }
+
+  /**
    * Audit a vote.
    *
    * @returns {undefined}
    */
   auditVote() {
-    cy.findByText("Vote").click();
-    cy.findByText("Encrypt vote").should("be.visible").click();
     cy.findByText("Audit vote").should("be.visible").click();
   }
 

--- a/decidim-bulletin_board-app/cypress/integration/sandbox/election.page.js
+++ b/decidim-bulletin_board-app/cypress/integration/sandbox/election.page.js
@@ -157,7 +157,7 @@ export class ElectionPage {
    */
   assertBallotHashIsPresent() {
     cy.findByText("Encrypt vote").should("be.disabled");
-    cy.get(".ballot-hash").should("include.text", "Your ballot identifier is:");
+    cy.findByText(/Your ballot identifier is:/).should("be.visible");
   }
 
   /**

--- a/decidim-bulletin_board-app/cypress/integration/sandbox/election.spec.js
+++ b/decidim-bulletin_board-app/cypress/integration/sandbox/election.spec.js
@@ -14,6 +14,8 @@ describe("Election", () => {
 
       page.startVote();
       page.assertVoteHasStarted();
+      page.encryptVote();
+      page.assertBallotHashIsPresent();
       page.auditVote();
       page.assertVoteHasBeenAudited();
       page.castVote();

--- a/decidim-bulletin_board-app/package-lock.json
+++ b/decidim-bulletin_board-app/package-lock.json
@@ -3348,6 +3348,7 @@
         "@babel/traverse": "7.12.12",
         "@babel/types": "7.12.12",
         "@graphql-tools/utils": "^7.0.0",
+        "@vue/compiler-sfc": "^3.0.4",
         "tslib": "~2.1.0"
       },
       "optionalDependencies": {
@@ -4069,6 +4070,7 @@
         "jest-resolve": "^26.6.2",
         "jest-util": "^26.6.2",
         "jest-worker": "^26.6.2",
+        "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -6549,6 +6551,7 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
+        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -6672,6 +6675,7 @@
       "integrity": "sha512-gnB85c3MGC7Nm9I/FkiasNBOKjOiO1RNuXXarQms37q4QMpWdlbBgD/VnOStA2faG1dpXMv31RFApjX1/QdgWQ==",
       "dev": true,
       "dependencies": {
+        "colors": "^1.1.2",
         "object-assign": "^4.1.0",
         "string-width": "^4.2.0"
       },
@@ -8269,7 +8273,8 @@
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -12114,6 +12119,7 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
+        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.6.2",
@@ -19381,6 +19387,7 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
+        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",

--- a/decidim-bulletin_board-ruby/CHANGELOG.md
+++ b/decidim-bulletin_board-ruby/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Added
+
+- The `Voter` returns the ballot hash after encrpyting the plain vote and before auditing or casting it
+
 ## [0.11.0] - 2021-02-18
 
 ## Changed

--- a/voting-scheme-dummy/src/voter_wrapper_adapter.js
+++ b/voting-scheme-dummy/src/voter_wrapper_adapter.js
@@ -18,7 +18,7 @@ export class VoterWrapperAdapter {
   }
 
   /**
-   * Process the message and update the wrapper status.
+   * Processes the message and updates the wrapper status.
    *
    * @param {String} messageType - The message type.
    * @param {Object} decodedData - An object with the data to process.


### PR DESCRIPTION
With this PR, the `ballot_hash` is available after `encrypting` the vote. Therefore, it can be displayed before deciding to `audit` or `cast` a vote. 