### PR TITLE
Use objects to represent JWKs everywhere

### DIFF
--- a/decidim-bulletin_board-app/app/commands/create_election.rb
+++ b/decidim-bulletin_board-app/app/commands/create_election.rb
@@ -67,7 +67,7 @@ class CreateElection < Rectify::Command
       Trustee.create!(
         name: trustee[:pretty_name],
         unique_id: trustee[:name],
-        public_key: JSON.parse(trustee[:public_key])
+        public_key: trustee[:public_key]
       )
   end
 

--- a/decidim-bulletin_board-app/spec/factories/messages.rb
+++ b/decidim-bulletin_board-app/spec/factories/messages.rb
@@ -67,7 +67,7 @@ FactoryBot.define do
     factory :json_bulletin_board do
       name { "bulletin-board" }
       pretty_name { "Bulletin Board" }
-      public_key { BulletinBoard.public_key.to_json }
+      public_key { BulletinBoard.public_key }
     end
 
     factory :json_authority do
@@ -77,7 +77,7 @@ FactoryBot.define do
 
       name { authority.unique_id }
       pretty_name { authority.name }
-      public_key { authority.public_key.to_json }
+      public_key { authority.public_key }
     end
 
     factory :json_trustee do
@@ -88,7 +88,7 @@ FactoryBot.define do
 
       name { pretty_name.parameterize }
       pretty_name { trustee.name }
-      public_key { private_key.export.to_json }
+      public_key { private_key.export }
     end
 
     factory :description do

--- a/decidim-bulletin_board-ruby/CHANGELOG.md
+++ b/decidim-bulletin_board-ruby/CHANGELOG.md
@@ -7,13 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## Added
+### Added
 
 - The `Voter` returns the ballot hash after encrpyting the plain vote and before auditing or casting it
 
+### Changed
+
+- The `create_election` command now expects objects representing the parts public keys.
+
 ## [0.11.0] - 2021-02-18
 
-## Changed
+### Changed
 
 - Changed the name of some settings\* to improve the readability of the code:
   - BB settings: `bulletin_board_server`\* and `bulletin_board_public_key`\*.


### PR DESCRIPTION
The `create_election` command now expects objects representing the parts public keys.