### PR TITLE
Convert dicts to hashes recursively

### DIFF
--- a/decidim-bulletin_board-app/app/commands/concerns/log_entry_command.rb
+++ b/decidim-bulletin_board-app/app/commands/concerns/log_entry_command.rb
@@ -76,7 +76,7 @@ module LogEntryCommand
       @response_log_entry = LogEntry.create!(
         election: election,
         message_id: Decidim::BulletinBoard::MessageIdentifier.format(election.unique_id, response_message["message_type"], :bulletin_board, BulletinBoard.unique_id),
-        signed_data: BulletinBoard.sign(response_message.to_h.merge(iat: Time.current.to_i)),
+        signed_data: BulletinBoard.sign(response_message.merge(iat: Time.current.to_i)),
         bulletin_board: true
       )
     end

--- a/decidim-bulletin_board-app/app/services/voting_scheme/election_guard.rb
+++ b/decidim-bulletin_board-app/app/services/voting_scheme/election_guard.rb
@@ -15,7 +15,7 @@ module VotingScheme
       result = state.process_message(message_identifier.type_subtype, PyCall::Dict.new(message))
       return tally_cast if message_identifier.type == "start_tally"
 
-      result
+      to_h(result)
     end
 
     def restore(data)
@@ -34,6 +34,14 @@ module VotingScheme
       end
 
       state.get_tally_cast
+    end
+
+    def to_h(dict)
+      return dict unless dict.is_a?(PyCall::Dict)
+
+      dict.inject({}) do |h, (k, v)|
+        h.update(k => to_h(v))
+      end
     end
   end
 end


### PR DESCRIPTION
This PR fixes a problem we had when processing the electionguard wrappers results. When we get nested `dict`s from python, it was only converting to hash the main object, but not the nested `dict`s. With this changes, this conversion is only done in the `electionguard` service, and it's done recursively.