### PR TITLE
fix: start tally must return a hash

### DIFF
--- a/decidim-bulletin_board-app/app/services/voting_scheme/election_guard.rb
+++ b/decidim-bulletin_board-app/app/services/voting_scheme/election_guard.rb
@@ -13,7 +13,7 @@ module VotingScheme
 
     def process_message(message_identifier, message)
       result = state.process_message(message_identifier.type_subtype, PyCall::Dict.new(message))
-      return tally_cast if message_identifier.type == "start_tally"
+      return to_h(tally_cast) if message_identifier.type == "start_tally"
 
       to_h(result)
     end


### PR DESCRIPTION
All the processed messages must return a hash and we made a mistake with the `start_tally` one.