### PR TITLE
Fix sequence order and hiding decodedData for results

### DIFF
--- a/decidim-bulletin_board-app/app/controllers/sandbox/elections_controller.rb
+++ b/decidim-bulletin_board-app/app/controllers/sandbox/elections_controller.rb
@@ -82,12 +82,10 @@ module Sandbox
     def questions
       @questions ||= params.require(:election).permit(questions: {})[:questions].to_h.values.map do |question|
         question.merge(
-          weight: question[:weight].to_i,
           max_selections: question[:max_selections].to_i,
           answers: question[:answers].values.map do |answer|
             {
-              slug: answer[:slug],
-              weight: answer[:weight].to_i
+              slug: answer[:slug]
             }
           end
         )

--- a/decidim-bulletin_board-app/app/graphql/types/log_entry_type.rb
+++ b/decidim-bulletin_board-app/app/graphql/types/log_entry_type.rb
@@ -6,6 +6,11 @@ module Types
 
     field :chained_hash, String, null: false
     field :content_hash, String, null: true
-    field :decoded_data, GraphQL::Types::JSON, null: false
+    field :decoded_data, GraphQL::Types::JSON, null: true do
+      def resolve(parent, _args, context)
+        log_entry = parent.object
+        log_entry.decoded_data if log_entry.visible_for_all? || log_entry.election.authority.api_key == context[:api_key]
+      end
+    end
   end
 end

--- a/decidim-bulletin_board-app/app/graphql/types/message_interface.rb
+++ b/decidim-bulletin_board-app/app/graphql/types/message_interface.rb
@@ -10,8 +10,8 @@ module Types
     field :message_id, String, null: false
     field :signed_data, String, null: true do
       def resolve(parent, _args, context)
-        log_entry = parent.object
-        log_entry.signed_data if log_entry.visible_for_all? || log_entry.election.authority.api_key == context[:api_key]
+        message = parent.object
+        message.signed_data if message.visible_for_all? || message.election.authority.api_key == context[:api_key]
       end
     end
   end

--- a/decidim-bulletin_board-app/app/javascript/decidim-bulletin_board/types.d.ts
+++ b/decidim-bulletin_board-app/app/javascript/decidim-bulletin_board/types.d.ts
@@ -60,7 +60,7 @@ export type LogEntry = MessageInterface & {
   chainedHash: Scalars['String'];
   client: Client;
   contentHash?: Maybe<Scalars['String']>;
-  decodedData: Scalars['JSON'];
+  decodedData?: Maybe<Scalars['JSON']>;
   election: Election;
   id: Scalars['ID'];
   messageId: Scalars['String'];

--- a/decidim-bulletin_board-app/app/models/concerns/message.rb
+++ b/decidim-bulletin_board-app/app/models/concerns/message.rb
@@ -12,8 +12,7 @@ module Message
 
     def visible_for_all?
       !VotingScheme.results_message?(
-        election.voting_scheme_name,
-        [message_identifier.type, message_identifier.subtype].compact.join(".")
+        election.voting_scheme_name, message_identifier.type_subtype
       ) || election.results_published?
     end
   end

--- a/decidim-bulletin_board-app/app/views/sandbox/elections/new.html.erb
+++ b/decidim-bulletin_board-app/app/views/sandbox/elections/new.html.erb
@@ -44,9 +44,6 @@
               <label>Slug: <input name="election[questions][<%= question_index %>][slug]" type="text" value="question-<%= question_index + 1 %>"></label>
           </li>
           <li>
-              <label>Weight: <input name="election[questions][<%= question_index %>][weight]" type="number" value="<%= question_index %>"></label>
-          </li>
-          <li>
               <label>Maximum selections: <input name="election[questions][<%= question_index %>][max_selections]" type="number" value="1" min="1" max="4"></label>
           </li>
           <li>
@@ -63,9 +60,6 @@
                 </li>
                 <li>
                     <label>Slug: <input name="election[questions][<%= question_index %>][answers][<%= answer_index %>][slug]" type="text" value="answer-<%= question_index + 1 %>-<%= answer_index + 1 %>"></label>
-                </li>
-                <li>
-                    <label>Weight: <input name="election[questions][<%= question_index %>][answers][<%= answer_index %>][weight]" type="number" value="<%= answer_index %>"></label>
                 </li>
                 <% end %>
               </ul>

--- a/decidim-bulletin_board-app/spec/queries/get_election_log_entries_spec.rb
+++ b/decidim-bulletin_board-app/spec/queries/get_election_log_entries_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe "GetElectionLogEntries" do
           logEntries {
             messageId
             signedData
+            decodedData
           }
         }
       }
@@ -29,7 +30,8 @@ RSpec.describe "GetElectionLogEntries" do
           logEntries: [
             {
               messageId: first_log_entry.message_id,
-              signedData: first_log_entry.signed_data
+              signedData: first_log_entry.signed_data,
+              decodedData: first_log_entry.decoded_data.deep_symbolize_keys
             }
           ]
         }
@@ -57,26 +59,30 @@ RSpec.describe "GetElectionLogEntries" do
 
     before { tally_cast && tally_share && end_tally }
 
-    it "hides the signed data" do
+    it "hides the signed and decoded data" do
       expect(subject.deep_symbolize_keys).to include(
         data: {
           election: {
             logEntries: [
               {
                 messageId: first_log_entry.message_id,
-                signedData: first_log_entry.signed_data
+                signedData: first_log_entry.signed_data,
+                decodedData: first_log_entry.decoded_data.deep_symbolize_keys
               },
               {
                 messageId: tally_cast.message_id,
-                signedData: tally_cast.signed_data
+                signedData: tally_cast.signed_data,
+                decodedData: tally_cast.decoded_data.deep_symbolize_keys
               },
               {
                 messageId: tally_share.message_id,
-                signedData: nil
+                signedData: nil,
+                decodedData: nil
               },
               {
                 messageId: end_tally.message_id,
-                signedData: nil
+                signedData: nil,
+                decodedData: nil
               }
             ]
           }
@@ -84,27 +90,31 @@ RSpec.describe "GetElectionLogEntries" do
       )
     end
 
-    shared_examples "showing the signed data" do
-      it "shows the signed data" do
+    shared_examples "showing the signed and decoded data" do
+      it "shows the signed and decoded data" do
         expect(subject.deep_symbolize_keys).to include(
           data: {
             election: {
               logEntries: [
                 {
                   messageId: first_log_entry.message_id,
-                  signedData: first_log_entry.signed_data
+                  signedData: first_log_entry.signed_data,
+                  decodedData: first_log_entry.decoded_data.deep_symbolize_keys
                 },
                 {
                   messageId: tally_cast.message_id,
-                  signedData: tally_cast.signed_data
+                  signedData: tally_cast.signed_data,
+                  decodedData: tally_cast.decoded_data.deep_symbolize_keys
                 },
                 {
                   messageId: tally_share.message_id,
-                  signedData: tally_share.signed_data
+                  signedData: tally_share.signed_data,
+                  decodedData: tally_share.decoded_data.deep_symbolize_keys
                 },
                 {
                   messageId: end_tally.message_id,
-                  signedData: end_tally.signed_data
+                  signedData: end_tally.signed_data,
+                  decodedData: end_tally.decoded_data.deep_symbolize_keys
                 }
               ]
             }
@@ -116,13 +126,13 @@ RSpec.describe "GetElectionLogEntries" do
     context "when the client is an authority" do
       let(:context) { { api_key: election.authority.api_key } }
 
-      it_behaves_like "showing the signed data"
+      it_behaves_like "showing the signed and decoded data"
     end
 
     context "when the results are published" do
       let(:election) { create(:election, :results_published) }
 
-      it_behaves_like "showing the signed data"
+      it_behaves_like "showing the signed and decoded data"
     end
   end
 end

--- a/decidim-bulletin_board-app/spec/services/voting_scheme_spec.rb
+++ b/decidim-bulletin_board-app/spec/services/voting_scheme_spec.rb
@@ -27,9 +27,10 @@ RSpec.describe VotingScheme do
     subject { described_class.results_message?(voting_scheme, type_subtype) }
 
     let(:voting_scheme) { "dummy" }
-    let(:type_subtype) { "tally.share" }
+    let(:type_subtype) { "end_tally" }
 
     it { expect(subject).to be_truthy }
+
 
     context "when asking for a non-result message" do
       let(:type_subtype) { "start_tally" }
@@ -37,10 +38,28 @@ RSpec.describe VotingScheme do
       it { expect(subject).to be_falsey }
     end
 
-    context "when asking for a scheme that doesn't consider it result" do
+    context "when asking for the tally shares message" do
+      let(:type_subtype) { "tally.share" }
+
+      it { expect(subject).to be_truthy }
+    end
+
+    context "when using the election_guard voting scheme" do
       let(:voting_scheme) { "election_guard" }
 
-      it { expect(subject).to be_falsey }
+      it { expect(subject).to be_truthy }
+
+      context "when asking for a non-result message" do
+        let(:type_subtype) { "start_tally" }
+
+        it { expect(subject).to be_falsey }
+      end
+
+      context "when asking for the tally shares message" do
+        let(:type_subtype) { "tally.trustee_share" }
+
+        it { expect(subject).to be_truthy }
+      end
     end
   end
 end

--- a/decidim-bulletin_board-app/spec/services/voting_scheme_spec.rb
+++ b/decidim-bulletin_board-app/spec/services/voting_scheme_spec.rb
@@ -31,7 +31,6 @@ RSpec.describe VotingScheme do
 
     it { expect(subject).to be_truthy }
 
-
     context "when asking for a non-result message" do
       let(:type_subtype) { "start_tally" }
 

--- a/decidim-bulletin_board-ruby/CHANGELOG.md
+++ b/decidim-bulletin_board-ruby/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- The `create_election` method doesn't need the `weight` field for questions and answers anymore. It will use the given order to create the `sequence_order` value.
+
 ## [0.13.0] - 2021-02-23
 
 ## [0.12.1] - 2021-02-22

--- a/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/authority/create_election.rb
+++ b/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/authority/create_election.rb
@@ -94,11 +94,11 @@ module Decidim
         end
 
         def contests
-          election_data[:questions].map do |question|
+          election_data[:questions].each_with_index.map do |question, index|
             {
               "@type": "CandidateContest",
               object_id: question[:slug],
-              sequence_order: question[:weight],
+              sequence_order: index,
               vote_variation: question[:max_selections] == 1 ? "one_of_m" : "n_of_m",
               name: default_text(question[:title]),
               number_elected: question[:answers].count,
@@ -110,10 +110,10 @@ module Decidim
         end
 
         def contest_answers(question)
-          question[:answers].map do |answer|
+          question[:answers].each_with_index.map do |answer, index|
             {
               object_id: "#{question[:slug]}_#{answer[:slug]}",
-              sequence_order: answer[:weight],
+              sequence_order: index,
               candidate_id: answer[:slug]
             }
           end

--- a/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/graphql/bb_schema.json
+++ b/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/graphql/bb_schema.json
@@ -442,13 +442,9 @@
 
               ],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "JSON",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "JSON",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null

--- a/decidim-bulletin_board-ruby/spec/decidim/bulletin_board/authority/create_election_spec.rb
+++ b/decidim-bulletin_board-ruby/spec/decidim/bulletin_board/authority/create_election_spec.rb
@@ -35,7 +35,6 @@ module Decidim
             questions: [
               {
                 slug: "question-1",
-                weight: 0,
                 max_selections: 1,
                 title: {
                   "en": "A question",
@@ -47,18 +46,15 @@ module Decidim
                 },
                 answers: [
                   {
-                    slug: "answer-1",
-                    weight: 3
+                    slug: "answer-1"
                   },
                   {
-                    slug: "answer-2",
-                    weight: 6
+                    slug: "answer-2"
                   }
                 ]
               },
               {
                 slug: "question-2",
-                weight: 23,
                 max_selections: 2,
                 title: {
                   "en": "Another question",
@@ -70,12 +66,10 @@ module Decidim
                 },
                 answers: [
                   {
-                    slug: "answer-3",
-                    weight: 123
+                    slug: "answer-3"
                   },
                   {
-                    slug: "answer-4",
-                    weight: 0
+                    slug: "answer-4"
                   }
                 ]
               }
@@ -167,14 +161,14 @@ module Decidim
                                           ballot_subtitle: { text: [{ language: "en", value: "A question description" },
                                                                     { language: "es", value: "Una descripción de pregunta" }] },
                                           ballot_selections: [{ object_id: "question-1_answer-1",
-                                                                sequence_order: 3,
+                                                                sequence_order: 0,
                                                                 candidate_id: "answer-1" },
                                                               { object_id: "question-1_answer-2",
-                                                                sequence_order: 6,
+                                                                sequence_order: 1,
                                                                 candidate_id: "answer-2" }] },
                                         { "@type": "CandidateContest",
                                           object_id: "question-2",
-                                          sequence_order: 23,
+                                          sequence_order: 1,
                                           vote_variation: "n_of_m",
                                           name: "Another question",
                                           number_elected: 2,
@@ -183,10 +177,10 @@ module Decidim
                                           ballot_subtitle: { text: [{ language: "en", value: "Another question description" },
                                                                     { language: "es", value: "Otra descripción de pregunta" }] },
                                           ballot_selections: [{ object_id: "question-2_answer-3",
-                                                                sequence_order: 123,
+                                                                sequence_order: 0,
                                                                 candidate_id: "answer-3" },
                                                               { object_id: "question-2_answer-4",
-                                                                sequence_order: 0,
+                                                                sequence_order: 1,
                                                                 candidate_id: "answer-4" }] }] } }
           end
 


### PR DESCRIPTION
This PR fixes two issues:
* For ElectionGuard, the `sequenceOrder` cannot have the same value for two questions or two answers in the same question. Instead of using the weight, this PR makes the create election to use the `sequenceOrder` based on the order in the list where the questions and answers are in the `electionData` parameters.
* In the GraphQL API, when the `signedData` was hidden, the `decodedData` were still visible. This PR fixes that.