### PR TITLE
feat: remove onSetup event and wait for setup to perform actions

### DIFF
--- a/decidim-bulletin_board-app/app/javascript/decidim-bulletin_board/tally/tally.component.js
+++ b/decidim-bulletin_board-app/app/javascript/decidim-bulletin_board/tally/tally.component.js
@@ -57,7 +57,6 @@ export class TallyComponent {
    *
    * @method bindEvents
    * @param {Object} eventCallbacks - An object that contains event callback functions.
-   * - {Function} onSetup - a function that is called when the trustee is set up.
    * - {Function} onEvent - a function that is called when an event is emitted from the trustee.
    * - {Function} onBindRestoreButton - a function that receives a callback function that will be called when
    *                                    the restore process must be started.
@@ -71,7 +70,6 @@ export class TallyComponent {
    * @returns {Promise<undefined>}
    */
   async bindEvents({
-    onSetup,
     onEvent,
     onBindRestoreButton,
     onBindStartButton,
@@ -80,12 +78,15 @@ export class TallyComponent {
     onStart,
     onTrusteeNeedsToBeRestored,
   }) {
+    const onSetupDone = this.trustee.setup();
+
     this.trustee.events.subscribe(onEvent);
 
     onBindStartButton(async (event) => {
+      onStart();
       event.preventDefault();
 
-      onStart();
+      await onSetupDone;
 
       if (await this.trustee.needsToBeRestored()) {
         onTrusteeNeedsToBeRestored();
@@ -95,7 +96,8 @@ export class TallyComponent {
       }
     });
 
-    onBindRestoreButton((event) => {
+    onBindRestoreButton(async (event) => {
+      await onSetupDone;
       const file = event.target.files[0];
       const reader = new FileReader();
       reader.onload = async ({ target }) => {
@@ -108,8 +110,5 @@ export class TallyComponent {
       };
       reader.readAsText(file);
     });
-
-    await this.trustee.setup();
-    onSetup();
   }
 }

--- a/decidim-bulletin_board-app/app/javascript/decidim-bulletin_board/vote/vote.component.js
+++ b/decidim-bulletin_board-app/app/javascript/decidim-bulletin_board/vote/vote.component.js
@@ -44,7 +44,6 @@ export class VoteComponent {
    *
    * @method bindEvents
    * @param {Object} eventCallbacks - An object that contains event callback functions.
-   * - {Function} onSetup - a function that is called when the voter is set up.
    * - {Function} onBindEncryptButton - a function that receives a callback function that will be called when encrypting the vote must be started
    * - {Function} onVoteEncryption - a function that is called when the vote gets encrypted
    * - {Function} castOrAuditBallot - a function that is called to cast or audit a ballot
@@ -60,7 +59,6 @@ export class VoteComponent {
    * @returns {Promise<undefined>}
    */
   async bindEvents({
-    onSetup,
     onBindEncryptButton,
     onStart,
     onVoteEncryption,
@@ -73,9 +71,11 @@ export class VoteComponent {
     onCastComplete,
     onInvalid,
   }) {
-    onBindEncryptButton(() => {
-      onStart();
+    const onSetupDone = this.voter.setup();
 
+    onBindEncryptButton(async () => {
+      onStart();
+      await onSetupDone;
       onVoteEncryption(
         (plainVote) => {
           this.voter.encrypt(plainVote).then((ballot) => {
@@ -103,8 +103,5 @@ export class VoteComponent {
         }
       );
     });
-
-    await this.voter.setup();
-    onSetup();
   }
 }

--- a/decidim-bulletin_board-app/app/javascript/packs/sandbox/key_ceremony.js
+++ b/decidim-bulletin_board-app/app/javascript/packs/sandbox/key_ceremony.js
@@ -86,9 +86,6 @@ $(() => {
           $backupButton.attr("download", backupFilename);
           $backupButton.on("click", onEventTriggered);
         },
-        onSetup() {
-          $startButton.show();
-        },
         onRestore() {
           $restoreButton.hide();
         },
@@ -108,6 +105,8 @@ $(() => {
           $backupButton.hide();
         },
       });
+
+      $startButton.show();
     };
 
     $trustee.on("change", ".private-key-input", async (event) => {

--- a/decidim-bulletin_board-app/app/javascript/packs/sandbox/tally.js
+++ b/decidim-bulletin_board-app/app/javascript/packs/sandbox/tally.js
@@ -62,19 +62,6 @@ $(() => {
     const bindComponentEvents = async () => {
       await component.bindEvents({
         onEvent(_event) {},
-        onSetup() {
-          $startButton.show();
-          $generateBackupButton.on("click", (event) => {
-            $generateBackupButton.attr(
-              "href",
-              `data:text/plain;charset=utf-8,{"trusteeId":"${trusteeContext.uniqueId}","electionId":"${electionUniqueId}","status":1,"electionTrusteesCount":3,"processedMessages":[]}`
-            );
-            $generateBackupButton.attr(
-              "download",
-              `${trusteeContext.uniqueId}-election-${electionUniqueId}.bak`
-            );
-          });
-        },
         onBindStartButton(onEventTriggered) {
           $startButton.on("click", onEventTriggered);
         },
@@ -99,6 +86,18 @@ $(() => {
           $generateBackupButton.hide();
           $restoreButton.hide();
         },
+      });
+
+      $startButton.show();
+      $generateBackupButton.on("click", (event) => {
+        $generateBackupButton.attr(
+          "href",
+          `data:text/plain;charset=utf-8,{"trusteeId":"${trusteeContext.uniqueId}","electionId":"${electionUniqueId}","status":1,"electionTrusteesCount":3,"processedMessages":[]}`
+        );
+        $generateBackupButton.attr(
+          "download",
+          `${trusteeContext.uniqueId}-election-${electionUniqueId}.bak`
+        );
       });
     };
 

--- a/decidim-bulletin_board-app/app/javascript/packs/sandbox/vote.js
+++ b/decidim-bulletin_board-app/app/javascript/packs/sandbox/vote.js
@@ -54,19 +54,16 @@ $(async () => {
   });
 
   await component.bindEvents({
-    onSetup() {
-      $encryptVote.removeAttr("disabled");
-    },
     onBindEncryptButton(onEventTriggered) {
       $encryptVote.on("click", onEventTriggered);
     },
-    onStart() {},
-    onVoteEncryption(validVoteFn, invalidVoteFn) {
+    onStart() {
       $vote.css("background", "");
       $auditMessage.hide();
       $doneMessage.hide();
       $encryptVote.prop("disabled", true);
-
+    },
+    onVoteEncryption(validVoteFn, invalidVoteFn) {
       try {
         const vote = JSON.parse($vote.val());
         if (!vote) {

--- a/decidim-bulletin_board-app/app/views/sandbox/elections/vote.html.erb
+++ b/decidim-bulletin_board-app/app/views/sandbox/elections/vote.html.erb
@@ -20,7 +20,7 @@
       <textarea cols="100" rows="5"><%= base_vote %></textarea>
     </p>
 
-    <p><button class="encrypt-vote" disabled>Encrypt vote</button></p>
+    <p><button class="encrypt-vote">Encrypt vote</button></p>
     <p class="ballot-hash"></p>
     <p>
       <button class="audit-vote">Audit vote</button>

--- a/decidim-bulletin_board-app/cypress/integration/sandbox/election.page.js
+++ b/decidim-bulletin_board-app/cypress/integration/sandbox/election.page.js
@@ -108,7 +108,14 @@ export class ElectionPage {
             );
 
           cy.findByText("Start").click();
-          cy.findByText("Backup").click({ timeout: 60_000 });
+        });
+    });
+
+    trustees.forEach(({ name }) => {
+      cy.findByText(name)
+        .parent("tr")
+        .within(() => {
+          cy.findByText("Backup").click({ timeout: 120_000 });
         });
     });
   }


### PR DESCRIPTION
We are removing the `onSetup` event so before performing any action with the wrapper adapter we are going wait for the setup to be done.

With this change, the UI is not responsible to enable the button in the appropriate moment.