### PR TITLE
Store vote requests to file from sandbox

### DIFF
--- a/decidim-bulletin_board-app/app/assets/stylesheets/sandbox/vote.scss
+++ b/decidim-bulletin_board-app/app/assets/stylesheets/sandbox/vote.scss
@@ -2,7 +2,8 @@
   .done-message,
   .audit-done-message,
   .audit-vote,
-  .cast-vote {
+  .cast-vote,
+  .store-vote {
     display: none;
   }
 }

--- a/decidim-bulletin_board-app/app/controllers/sandbox/elections_controller.rb
+++ b/decidim-bulletin_board-app/app/controllers/sandbox/elections_controller.rb
@@ -25,7 +25,7 @@ module Sandbox
 
     def vote
       return unless request.post?
-      return file_client.cast_vote(election_id, params[:voter_id], params[:encrypted_ballot]) if params[:store_to_file]
+      return file_client.cast_vote(election_id, params[:voter_id], params[:encrypted_ballot]) if params[:store_to_file].present?
 
       bulletin_board_client.cast_vote(election_id, params[:voter_id], params[:encrypted_ballot])
     end
@@ -133,7 +133,7 @@ module Sandbox
     end
 
     def file_client
-      @file_client ||= Decidim::BulletinBoard::Client.new(bulletin_board_settings, "storage/input.csv")
+      @file_client ||= Decidim::BulletinBoard::FileClient.new("storage/input.csv", bulletin_board_settings)
     end
 
     def bulletin_board_settings

--- a/decidim-bulletin_board-app/app/controllers/sandbox/elections_controller.rb
+++ b/decidim-bulletin_board-app/app/controllers/sandbox/elections_controller.rb
@@ -25,6 +25,7 @@ module Sandbox
 
     def vote
       return unless request.post?
+      return file_client.cast_vote(election_id, params[:voter_id], params[:encrypted_ballot]) if params[:store_to_file]
 
       bulletin_board_client.cast_vote(election_id, params[:voter_id], params[:encrypted_ballot])
     end
@@ -129,6 +130,10 @@ module Sandbox
 
     def bulletin_board_client
       @bulletin_board_client ||= Decidim::BulletinBoard::Client.new(bulletin_board_settings)
+    end
+
+    def file_client
+      @file_client ||= Decidim::BulletinBoard::Client.new(bulletin_board_settings, "storage/input.csv")
     end
 
     def bulletin_board_settings

--- a/decidim-bulletin_board-app/app/javascript/packs/sandbox/vote.js
+++ b/decidim-bulletin_board-app/app/javascript/packs/sandbox/vote.js
@@ -3,11 +3,16 @@ import { VoteComponent } from "../decidim-bulletin_board";
 import { VoterWrapperAdapter as DummyVoterWrapperAdapter } from "voting-scheme-dummy";
 import { VoterWrapperAdapter as ElectionGuardVoterWrapperAdapter } from "voting-scheme-election_guard";
 
+const STORE_ACTION = "store";
+const CAST_ACTION = "cast";
+let performedAction = "";
+
 $(async () => {
   // UI Elements
   const $voter = $(".voter");
   const $encryptVote = $voter.find(".encrypt-vote");
   const $castVote = $voter.find(".cast-vote");
+  const $storeVote = $voter.find(".store-vote");
   const $auditVote = $voter.find(".audit-vote");
   const $vote = $voter.find("textarea");
   const $voterId = $voter.find("input");
@@ -79,12 +84,21 @@ $(async () => {
       $encryptVote.prop("disabled", true);
       $castVote.show();
       $auditVote.show();
+      $storeVote.show();
     },
     onBindAuditBallotButton(onEventTriggered) {
       $auditVote.on("click", onEventTriggered);
     },
     onBindCastBallotButton(onEventTriggered) {
+      $castVote.on("click", () => {
+        setPerformedAction(CAST_ACTION);
+      });
       $castVote.on("click", onEventTriggered);
+
+      $storeVote.on("click", () => {
+        setPerformedAction(STORE_ACTION);
+      });
+      $storeVote.on("click", onEventTriggered);
     },
     onAuditBallot(auditedVote, auditFileName) {
       const vote = JSON.stringify(auditedVote);
@@ -110,6 +124,7 @@ $(async () => {
         data: JSON.stringify({
           voter_id: $voterId.val(),
           encrypted_ballot: encryptedBallot,
+          store_to_file: performedAction === STORE_ACTION,
         }), // eslint-disable-line camelcase
         headers: {
           "X-CSRF-Token": $("meta[name=csrf-token]").attr("content"),
@@ -119,6 +134,7 @@ $(async () => {
     onCastComplete() {
       $castVote.prop("disabled", true);
       $auditVote.prop("disabled", true);
+      $storeVote.prop("disabled", true);
       $doneMessage.show();
       $vote.css("background", "green");
     },
@@ -127,3 +143,7 @@ $(async () => {
     },
   });
 });
+
+const setPerformedAction = (action) => {
+  performedAction = action;
+};

--- a/decidim-bulletin_board-app/app/javascript/packs/sandbox/vote.js
+++ b/decidim-bulletin_board-app/app/javascript/packs/sandbox/vote.js
@@ -3,10 +3,6 @@ import { VoteComponent } from "../decidim-bulletin_board";
 import { VoterWrapperAdapter as DummyVoterWrapperAdapter } from "voting-scheme-dummy";
 import { VoterWrapperAdapter as ElectionGuardVoterWrapperAdapter } from "voting-scheme-election_guard";
 
-const STORE_ACTION = "store";
-const CAST_ACTION = "cast";
-let performedAction = "";
-
 $(async () => {
   // UI Elements
   const $voter = $(".voter");
@@ -19,6 +15,12 @@ $(async () => {
   const $doneMessage = $voter.find(".done-message");
   const $auditMessage = $voter.find(".audit-done-message");
   const $ballotHash = $voter.find(".ballot-hash");
+  const STORE_ACTION = "store";
+  const CAST_ACTION = "cast";
+  let performedAction = "";
+  const setPerformedAction = (action) => {
+    performedAction = action;
+  };
 
   $vote.on("change", (event) => {
     $vote.css("border", "");
@@ -90,15 +92,15 @@ $(async () => {
       $auditVote.on("click", onEventTriggered);
     },
     onBindCastBallotButton(onEventTriggered) {
-      $castVote.on("click", () => {
+      $castVote.on("click", (event) => {
         setPerformedAction(CAST_ACTION);
+        onEventTriggered(event);
       });
-      $castVote.on("click", onEventTriggered);
 
-      $storeVote.on("click", () => {
+      $storeVote.on("click", (event) => {
         setPerformedAction(STORE_ACTION);
+        onEventTriggered(event);
       });
-      $storeVote.on("click", onEventTriggered);
     },
     onAuditBallot(auditedVote, auditFileName) {
       const vote = JSON.stringify(auditedVote);
@@ -143,7 +145,3 @@ $(async () => {
     },
   });
 });
-
-const setPerformedAction = (action) => {
-  performedAction = action;
-};

--- a/decidim-bulletin_board-app/app/views/sandbox/elections/vote.html.erb
+++ b/decidim-bulletin_board-app/app/views/sandbox/elections/vote.html.erb
@@ -25,6 +25,7 @@
     <p>
       <button class="audit-vote">Audit vote</button>
       <button class="cast-vote">Cast vote</button>
+      <button class="store-vote">Store vote to file</button>
     </p>
     <p>
       <span class="done-message">Your vote has been casted successfully</span>

--- a/decidim-bulletin_board-ruby/lib/decidim/bulletin_board.rb
+++ b/decidim-bulletin_board-ruby/lib/decidim/bulletin_board.rb
@@ -8,6 +8,7 @@ require "graphlient"
 require "wisper"
 
 require "decidim/bulletin_board/client"
+require "decidim/bulletin_board/file_client"
 require "decidim/bulletin_board/engine"
 require "decidim/bulletin_board/jwk_utils"
 require "decidim/bulletin_board/message_identifier"

--- a/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/client.rb
+++ b/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/client.rb
@@ -19,9 +19,9 @@ module Decidim
   module BulletinBoard
     # The Bulletin Board client
     class Client
-      def initialize(config = Decidim::BulletinBoard)
+      def initialize(config = Decidim::BulletinBoard, file_path = nil)
         @settings = Settings.new(config)
-        @graphql = Graphql::Factory.client_for(settings)
+        @graphql = file_path.present? ? Graphql::Factory.client_for_file(settings, file_path) : Graphql::Factory.client_for(settings)
       end
 
       delegate :configured?,

--- a/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/client.rb
+++ b/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/client.rb
@@ -19,9 +19,9 @@ module Decidim
   module BulletinBoard
     # The Bulletin Board client
     class Client
-      def initialize(config = Decidim::BulletinBoard, file_path = nil)
+      def initialize(config = Decidim::BulletinBoard)
         @settings = Settings.new(config)
-        @graphql = file_path.present? ? Graphql::Factory.client_for_file(settings, file_path) : Graphql::Factory.client_for(settings)
+        @graphql = Graphql::Factory.client_for(settings)
       end
 
       delegate :configured?,

--- a/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/file_client.rb
+++ b/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/file_client.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Decidim
+  module BulletinBoard
+    # Client to store GraphQL requests to a CSV file instead of sending them to the BulletinBoard
+    # It is intended to be used for load testing
+    class FileClient < Decidim::BulletinBoard::Client
+      def initialize(file_path, config = Decidim::BulletinBoard)
+        @settings = Settings.new(config)
+        @graphql = Graphql::Factory.client_for_file(settings, file_path)
+      end
+    end
+  end
+end

--- a/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/graphql/factory.rb
+++ b/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/graphql/factory.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "decidim/bulletin_board/graphql/file_adapter"
+
 module Decidim
   module BulletinBoard
     module Graphql
@@ -8,6 +10,15 @@ module Decidim
         def self.client_for(settings)
           Graphlient::Client.new(settings.bulletin_board_server,
                                  schema_path: File.join(__dir__, "bb_schema.json"),
+                                 headers: {
+                                   "Authorization" => settings.authority_api_key
+                                 })
+        end
+
+        def self.client_for_file(settings, file_path)
+          Graphlient::Client.new(file_path,
+                                 schema_path: File.join(__dir__, "bb_schema.json"),
+                                 http: FileAdapter,
                                  headers: {
                                    "Authorization" => settings.authority_api_key
                                  })

--- a/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/graphql/file_adapter.rb
+++ b/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/graphql/file_adapter.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Decidim
+  module BulletinBoard
+    module Graphql
+      class FileAdapter
+        attr_reader :file_name
+
+        def initialize(file_name, _options = {}, &_block)
+          @file_name = file_name
+        end
+
+        def execute(document:, operation_name: nil, variables: {}, context: {})
+          body = {}
+          body["query"] = document.to_query_string
+          body["variables"] = variables if variables.any?
+          body["operationName"] = operation_name if operation_name
+
+          File.open(file_name, "a+") do |f|
+            f.puts "#{JSON.generate(body)};#{context[:headers]["Authorization"]}"
+          end
+
+          { "data" => { "vote" => {} } }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a "Store vote to file" button to the sandbox that allows to write the vote's GraphQL request to a CSV file.

![Screenshot 2021-03-03 at 08 42 23](https://user-images.githubusercontent.com/5033945/109771540-33be8b80-7bfd-11eb-8949-af2e22293d93.png)

On the JS side, to avoid touching the library, we're binding the new button to the same events as "Cast ballot" and [setting a global variable to know which of the buttons has been clicked](https://github.com/decidim/decidim-bulletin-board/pull/132/files#diff-6b6dc1d14767f3dc0fe9429248dc49e46229ccefc48fbfdb290261cf89aee7d4R98-R100). This information is then sent to the controller.

On the ruby gem side, we added a [new client to the factory](https://github.com/decidim/decidim-bulletin-board/pull/132/files#diff-bbc31b0d371b259d6e80a1e1de811ab7df05d73fe3d7f4769ea6772118048332R18-R25) that employs a newly crafted adapter to store the request to a file in CSV format ([here are the adapters available in Graphlient for reference](https://github.com/ashkan18/graphlient/tree/master/lib/graphlient/adapters))