### PR TITLE
add codespaces to config.hosts

### DIFF
--- a/decidim-bulletin_board-app/config/environments/development.rb
+++ b/decidim-bulletin_board-app/config/environments/development.rb
@@ -65,4 +65,5 @@ Rails.application.configure do
 
   # Allow accessing with .lvh.me URLs
   config.hosts << /[a-z0-9-]+\.lvh\.me/
+  config.hosts << /[a-z0-9-]+\.apps.codespaces.githubusercontent.com/
 end


### PR DESCRIPTION
add github codespaces host to `development` environment.

Before this was the error

```
Blocked host: xxxxxxx.apps.codespaces.githubusercontent.com To allow requests to xxxxxxx.apps.codespaces.githubusercontent.com
```