### PR TITLE
Generate bulk votes from sandbox - dummy schema

### DIFF
--- a/decidim-bulletin_board-app/app/assets/config/manifest.js
+++ b/decidim-bulletin_board-app/app/assets/config/manifest.js
@@ -7,3 +7,4 @@
 //= link sandbox/key_ceremony.css
 //= link sandbox/tally.css
 //= link sandbox/vote.css
+//= link sandbox/index.css

--- a/decidim-bulletin_board-app/app/assets/stylesheets/application.css
+++ b/decidim-bulletin_board-app/app/assets/stylesheets/application.css
@@ -1,0 +1,3 @@
+body {
+  max-width: unset;
+}

--- a/decidim-bulletin_board-app/app/assets/stylesheets/sandbox/index.scss
+++ b/decidim-bulletin_board-app/app/assets/stylesheets/sandbox/index.scss
@@ -1,0 +1,11 @@
+.generate-votes-input-section {
+  display: none;
+}
+
+.show-input-button {
+  display: inline;
+}
+
+.generate-votes-input {
+  width: 55px;
+}

--- a/decidim-bulletin_board-app/app/assets/stylesheets/sandbox/vote.scss
+++ b/decidim-bulletin_board-app/app/assets/stylesheets/sandbox/vote.scss
@@ -2,8 +2,7 @@
   .done-message,
   .audit-done-message,
   .audit-vote,
-  .cast-vote,
-  .store-vote {
+  .cast-vote {
     display: none;
   }
 }

--- a/decidim-bulletin_board-app/app/controllers/sandbox/elections_controller.rb
+++ b/decidim-bulletin_board-app/app/controllers/sandbox/elections_controller.rb
@@ -7,6 +7,8 @@ module Sandbox
     helper_method :base_vote, :random_voter_id
     helper_method :election_results
 
+    BULK_VOTES_FILE = "storage/bulk_votes.csv"
+
     def index; end
 
     def create
@@ -34,6 +36,8 @@ module Sandbox
     end
 
     def generate_bulk_votes
+      delete_bulk_votes_file
+
       number_of_votes_to_generate.times do
         file_client.cast_vote(election_id, SecureRandom.hex, random_encrypted_vote)
       end
@@ -150,7 +154,7 @@ module Sandbox
     end
 
     def file_client
-      @file_client ||= Decidim::BulletinBoard::FileClient.new("storage/input.csv", bulletin_board_settings)
+      @file_client ||= Decidim::BulletinBoard::FileClient.new(BULK_VOTES_FILE, bulletin_board_settings)
     end
 
     def bulletin_board_settings
@@ -178,6 +182,10 @@ module Sandbox
 
     def random_voter_id
       @random_voter_id ||= SecureRandom.hex
+    end
+
+    def delete_bulk_votes_file
+      File.delete(BULK_VOTES_FILE) if File.exist?(BULK_VOTES_FILE)
     end
 
     def number_of_votes_to_generate

--- a/decidim-bulletin_board-app/app/controllers/sandbox/elections_controller.rb
+++ b/decidim-bulletin_board-app/app/controllers/sandbox/elections_controller.rb
@@ -32,7 +32,6 @@ module Sandbox
 
     def vote
       return unless request.post?
-      return file_client.cast_vote(election_id, params[:voter_id], params[:encrypted_ballot]) if params[:store_to_file].present?
 
       bulletin_board_client.cast_vote(election_id, params[:voter_id], params[:encrypted_ballot])
     end
@@ -174,7 +173,7 @@ module Sandbox
       @base_vote ||= election.manifest[:description][:contests].map do |contest|
         [
           contest[:object_id],
-          contest[:ballot_selections].sample(Random.rand(contest[:number_elected]))
+          contest[:ballot_selections].sample(Random.rand(contest[:number_elected]+1))
                                      .map { |ballot_selection| ballot_selection[:object_id] }
         ]
       end.to_h.to_json

--- a/decidim-bulletin_board-app/app/controllers/sandbox/elections_controller.rb
+++ b/decidim-bulletin_board-app/app/controllers/sandbox/elections_controller.rb
@@ -173,7 +173,7 @@ module Sandbox
       @base_vote ||= election.manifest[:description][:contests].map do |contest|
         [
           contest[:object_id],
-          contest[:ballot_selections].sample(Random.rand(contest[:number_elected]+1))
+          contest[:ballot_selections].sample(Random.rand(contest[:number_elected] + 1))
                                      .map { |ballot_selection| ballot_selection[:object_id] }
         ]
       end.to_h.to_json

--- a/decidim-bulletin_board-app/app/controllers/sandbox/elections_controller.rb
+++ b/decidim-bulletin_board-app/app/controllers/sandbox/elections_controller.rb
@@ -6,8 +6,10 @@ module Sandbox
     helper_method :bulletin_board_server, :authority_slug, :authority_public_key
     helper_method :base_vote, :random_voter_id
     helper_method :election_results
+    helper_method :default_bulk_votes_number
 
     BULK_VOTES_FILE = "storage/bulk_votes.csv"
+    DEFAULT_BULK_VOTES_NUMBER = 1000
 
     def index; end
 
@@ -41,8 +43,6 @@ module Sandbox
       number_of_votes_to_generate.times do
         file_client.cast_vote(election_id, SecureRandom.hex, random_encrypted_vote)
       end
-
-      go_back
     end
 
     def end_vote
@@ -189,7 +189,11 @@ module Sandbox
     end
 
     def number_of_votes_to_generate
-      params[:number_of_votes].presence || 10
+      params[:number_of_votes]&.to_i || 1000
+    end
+
+    def default_bulk_votes_number
+      DEFAULT_BULK_VOTES_NUMBER
     end
 
     def random_encrypted_vote

--- a/decidim-bulletin_board-app/app/javascript/packs/sandbox/index.js
+++ b/decidim-bulletin_board-app/app/javascript/packs/sandbox/index.js
@@ -21,7 +21,7 @@ $(async () => {
     $(event.target).prop("disabled", true);
 
     $.ajax({
-      url: `elections/${electionId}/generate_bulk_votes`,
+      url: `${electionId}/generate_bulk_votes`,
       method: "POST",
       contentType: "application/json",
       data: JSON.stringify({

--- a/decidim-bulletin_board-app/app/javascript/packs/sandbox/index.js
+++ b/decidim-bulletin_board-app/app/javascript/packs/sandbox/index.js
@@ -21,7 +21,7 @@ $(async () => {
     $(event.target).prop("disabled", true);
 
     $.ajax({
-      url: `${electionId}/generate_bulk_votes`,
+      url: `/sandbox/elections/${electionId}/generate_bulk_votes`,
       method: "POST",
       contentType: "application/json",
       data: JSON.stringify({

--- a/decidim-bulletin_board-app/app/javascript/packs/sandbox/index.js
+++ b/decidim-bulletin_board-app/app/javascript/packs/sandbox/index.js
@@ -7,13 +7,17 @@ $(async () => {
 
   $showInputButton.on("click", (event) => {
     $(event.target).hide();
-    $(event.target).siblings(".generate-votes-input-section").css("display", "inline");
+    $(event.target)
+      .siblings(".generate-votes-input-section")
+      .css("display", "inline");
   });
 
   $generateVotesButton.on("click", (event) => {
     const electionId = $(event.target).closest(".election").data("id");
-    const votesToGenerate = $(event.target).siblings(".generate-votes-input").val();
-    $(event.target).html(`Generating ${votesToGenerate} votes...`)
+    const votesToGenerate = $(event.target)
+      .siblings(".generate-votes-input")
+      .val();
+    $(event.target).html(`Generating ${votesToGenerate} votes...`);
     $(event.target).prop("disabled", true);
 
     $.ajax({
@@ -27,7 +31,7 @@ $(async () => {
         "X-CSRF-Token": $("meta[name=csrf-token]").attr("content"),
       },
     })
-    .done(() => $(event.target).html(`${votesToGenerate} votes generated!`))
-    .fail(() => $(event.target).html(`Failed, retry!`))
+      .done(() => $(event.target).html(`${votesToGenerate} votes generated!`))
+      .fail(() => $(event.target).html(`Failed, retry!`));
   });
 });

--- a/decidim-bulletin_board-app/app/javascript/packs/sandbox/index.js
+++ b/decidim-bulletin_board-app/app/javascript/packs/sandbox/index.js
@@ -1,0 +1,33 @@
+import $ from "jquery";
+
+$(async () => {
+  // UI Elements
+  const $showInputButton = $(".show-input-button");
+  const $generateVotesButton = $(".generate-votes-button");
+
+  $showInputButton.on("click", (event) => {
+    $(event.target).hide();
+    $(event.target).siblings(".generate-votes-input-section").css("display", "inline");
+  });
+
+  $generateVotesButton.on("click", (event) => {
+    const electionId = $(event.target).closest(".election").data("id");
+    const votesToGenerate = $(event.target).siblings(".generate-votes-input").val();
+    $(event.target).html(`Generating ${votesToGenerate} votes...`)
+    $(event.target).prop("disabled", true);
+
+    $.ajax({
+      url: `elections/${electionId}/generate_bulk_votes`,
+      method: "POST",
+      contentType: "application/json",
+      data: JSON.stringify({
+        number_of_votes: votesToGenerate,
+      }), // eslint-disable-line camelcase
+      headers: {
+        "X-CSRF-Token": $("meta[name=csrf-token]").attr("content"),
+      },
+    })
+    .done(() => $(event.target).html(`${votesToGenerate} votes generated!`))
+    .fail(() => $(event.target).html(`Failed, retry!`))
+  });
+});

--- a/decidim-bulletin_board-app/app/javascript/packs/sandbox/vote.js
+++ b/decidim-bulletin_board-app/app/javascript/packs/sandbox/vote.js
@@ -8,19 +8,12 @@ $(async () => {
   const $voter = $(".voter");
   const $encryptVote = $voter.find(".encrypt-vote");
   const $castVote = $voter.find(".cast-vote");
-  const $storeVote = $voter.find(".store-vote");
   const $auditVote = $voter.find(".audit-vote");
   const $vote = $voter.find("textarea");
   const $voterId = $voter.find("input");
   const $doneMessage = $voter.find(".done-message");
   const $auditMessage = $voter.find(".audit-done-message");
   const $ballotHash = $voter.find(".ballot-hash");
-  const STORE_ACTION = "store";
-  const CAST_ACTION = "cast";
-  let performedAction = "";
-  const setPerformedAction = (action) => {
-    performedAction = action;
-  };
 
   $vote.on("change", (event) => {
     $vote.css("border", "");
@@ -87,21 +80,12 @@ $(async () => {
       $encryptVote.prop("disabled", true);
       $castVote.show();
       $auditVote.show();
-      $storeVote.show();
     },
     onBindAuditBallotButton(onEventTriggered) {
       $auditVote.on("click", onEventTriggered);
     },
     onBindCastBallotButton(onEventTriggered) {
-      $castVote.on("click", (event) => {
-        setPerformedAction(CAST_ACTION);
-        onEventTriggered(event);
-      });
-
-      $storeVote.on("click", (event) => {
-        setPerformedAction(STORE_ACTION);
-        onEventTriggered(event);
-      });
+      $castVote.on("click", onEventTriggered);
     },
     onAuditBallot(auditedVote, auditFileName) {
       const vote = JSON.stringify(auditedVote);
@@ -137,7 +121,6 @@ $(async () => {
     onCastComplete() {
       $castVote.prop("disabled", true);
       $auditVote.prop("disabled", true);
-      $storeVote.prop("disabled", true);
       $doneMessage.show();
       $vote.css("background", "green");
     },

--- a/decidim-bulletin_board-app/app/javascript/packs/sandbox/vote.js
+++ b/decidim-bulletin_board-app/app/javascript/packs/sandbox/vote.js
@@ -111,7 +111,6 @@ $(async () => {
         data: JSON.stringify({
           voter_id: $voterId.val(),
           encrypted_ballot: encryptedBallot,
-          store_to_file: performedAction === STORE_ACTION,
         }), // eslint-disable-line camelcase
         headers: {
           "X-CSRF-Token": $("meta[name=csrf-token]").attr("content"),

--- a/decidim-bulletin_board-app/app/views/sandbox/elections/index.html.erb
+++ b/decidim-bulletin_board-app/app/views/sandbox/elections/index.html.erb
@@ -1,3 +1,5 @@
+<%= stylesheet_link_tag "sandbox/index" %>
+
 <div class="intro">
   <div class="version">Bulletin Board Version <%= Decidim::BulletinBoard::VERSION %></div>
 
@@ -19,7 +21,7 @@
     </thead>
     <tbody>
       <% elections.each do |election| %>
-        <tr>
+        <tr class="election" data-id="<%= election.id %>">
           <td><%= election.unique_id %></td>
           <td><%= election.title.values.first %></td>
           <td><%= election.status %></td>
@@ -34,9 +36,12 @@
             <% elsif election.vote? %>
               <%= link_to "Vote", vote_sandbox_election_path(election) %> |
               <%= link_to "End vote", end_vote_sandbox_election_path(election) %>  |
-              <%= link_to "Generate bulk votes", generate_bulk_votes_sandbox_election_path(election) %>
-            <% end %>
-            <% if election.vote_ended? %>
+              <button class="show-input-button"> Generate bulk votes </button>
+              <div class="generate-votes-input-section">
+                <input class="generate-votes-input" type="number" placeholder="How many votes?" value="<%= default_bulk_votes_number %>"/>
+                <button class="generate-votes-button">Generate votes</button>
+              </div>
+            <% elsif election.vote_ended? %>
               <%= link_to "Start tally", start_tally_sandbox_election_path(election) %>
             <% elsif election.tally? %>
               <%= link_to "Perform tally", tally_sandbox_election_path(election) %>
@@ -52,3 +57,6 @@
 
   <%= link_to "Setup new election", new_sandbox_election_path %>
 </div>
+
+
+<%= javascript_packs_with_chunks_tag "sandbox/index" %>

--- a/decidim-bulletin_board-app/app/views/sandbox/elections/index.html.erb
+++ b/decidim-bulletin_board-app/app/views/sandbox/elections/index.html.erb
@@ -33,8 +33,10 @@
               <%= link_to "Start vote", start_vote_sandbox_election_path(election) %>
             <% elsif election.vote? %>
               <%= link_to "Vote", vote_sandbox_election_path(election) %> |
-              <%= link_to "End vote", end_vote_sandbox_election_path(election) %>
-            <% elsif election.vote_ended? %>
+              <%= link_to "End vote", end_vote_sandbox_election_path(election) %>  |
+              <%= link_to "Generate bulk votes", generate_bulk_votes_sandbox_election_path(election) %>
+            <% end %>
+            <% if election.vote_ended? %>
               <%= link_to "Start tally", start_tally_sandbox_election_path(election) %>
             <% elsif election.tally? %>
               <%= link_to "Perform tally", tally_sandbox_election_path(election) %>

--- a/decidim-bulletin_board-app/app/views/sandbox/elections/vote.html.erb
+++ b/decidim-bulletin_board-app/app/views/sandbox/elections/vote.html.erb
@@ -26,7 +26,6 @@
     <p>
       <button class="audit-vote">Audit vote</button>
       <button class="cast-vote">Cast vote</button>
-      <button class="store-vote">Store vote to file</button>
     </p>
     <p>
       <span class="done-message">Your vote has been casted successfully</span>

--- a/decidim-bulletin_board-app/config/routes.rb
+++ b/decidim-bulletin_board-app/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
           get :start_vote
           get :vote
           post :vote
-          get :generate_bulk_votes
+          post :generate_bulk_votes
           get :end_vote
           get :start_tally
           get :tally

--- a/decidim-bulletin_board-app/config/routes.rb
+++ b/decidim-bulletin_board-app/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
           get :start_vote
           get :vote
           post :vote
+          get :generate_bulk_votes
           get :end_vote
           get :start_tally
           get :tally


### PR DESCRIPTION
Allows generating a user-defined number of votes encrypted with the dummy schema, replicating https://github.com/decidim/decidim-bulletin-board/blob/develop/voting_schemes/dummy/js-adapter/src/voter_wrapper.js#L78.

The votes are stored in a CSV file that will later be used by JMeter.

For the moment being, the logic is in the controller and does not check what schema the election uses.
When introducing support to the EG schema these things will be addressed.

In my local machine, it takes about 20 second per 1000 votes.

[bulk votes](https://user-images.githubusercontent.com/5033945/109857627-2fc15680-7c5b-11eb-8ed1-53e3cbf6c82d.mov)


