### PR TITLE
Fix bulk vote CSV format

### DIFF
--- a/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/graphql/file_adapter.rb
+++ b/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/graphql/file_adapter.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "csv"
+
 module Decidim
   module BulletinBoard
     module Graphql
@@ -16,8 +18,8 @@ module Decidim
           body["variables"] = variables if variables.any?
           body["operationName"] = operation_name if operation_name
 
-          File.open(file_name, "a+") do |f|
-            f.puts "#{JSON.generate(body)};#{context[:headers]["Authorization"]}"
+          CSV.open(file_name, "a+") do |csv|
+            csv << [JSON.generate(body), context[:headers]["Authorization"]]
           end
 
           { "data" => { "vote" => {} } }


### PR DESCRIPTION
The CSV generated in #136 needed manual adjustments (double `"` around strings in JSON) to be read by JMeter.
Now using the standard CSV ruby gem that outputs in a format directly processable by JMeter.