### PR TITLE
Election fixes: chained_hash generation and election creating

### DIFF
--- a/decidim-bulletin_board-app/app/models/election.rb
+++ b/decidim-bulletin_board-app/app/models/election.rb
@@ -3,7 +3,7 @@
 class Election < ApplicationRecord
   belongs_to :authority
   has_many :election_trustees
-  has_many :trustees, through: :election_trustees
+  has_many :trustees, -> { order(id: :asc) }, through: :election_trustees
   has_many :log_entries, -> { order(id: :asc) }
 
   has_one_attached :verifiable_results

--- a/decidim-bulletin_board-app/app/models/log_entry.rb
+++ b/decidim-bulletin_board-app/app/models/log_entry.rb
@@ -28,6 +28,6 @@ class LogEntry < ApplicationRecord
   end
 
   def previous_hash
-    election.log_entries.last&.chained_hash || election.unique_id
+    LogEntry.where(election: election).order(id: :desc).pick(:chained_hash) || election.unique_id
   end
 end

--- a/decidim-bulletin_board-app/app/models/log_entry.rb
+++ b/decidim-bulletin_board-app/app/models/log_entry.rb
@@ -9,7 +9,7 @@ class LogEntry < ApplicationRecord
 
   before_create do
     self.content_hash = Digest::SHA256.hexdigest(content) if content
-    self.chained_hash = Digest::SHA256.hexdigest([previous_hash, decoded_data].join("."))
+    self.chained_hash = Digest::SHA256.hexdigest([previous_hash, signed_data].join("."))
     self.iat = decoded_data[:iat]
     self.message_type = message_identifier.type
     self.author_unique_id = message_identifier.author_id

--- a/decidim-bulletin_board-app/spec/factories/models.rb
+++ b/decidim-bulletin_board-app/spec/factories/models.rb
@@ -127,8 +127,6 @@ FactoryBot.define do
   end
 
   factory :log_entry, traits: [:message_model] do
-    content_hash { Digest::SHA256.hexdigest(message["content"]) if message["content"] }
-
     trait :by_trustee do
       client { Trustee.first }
       private_key { Test::PrivateKeys.trustees_private_keys.first }

--- a/decidim-bulletin_board-app/spec/models/log_entry_spec.rb
+++ b/decidim-bulletin_board-app/spec/models/log_entry_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "LogEntry" do
+  subject { log_entry }
+
+  let(:election) { create(:election) }
+  let(:log_entry) { build(:log_entry, election: election, message: message) }
+  let(:iat) { Time.current.to_i }
+  let(:message) do
+    {
+      message_id: "author.1.type.subtype+a.author",
+      content: "the message content",
+      data: 123,
+      more_data: true,
+      iat: iat
+    }.with_indifferent_access
+  end
+
+  describe "#content" do
+    subject { log_entry.content }
+
+    it "returns the message content" do
+      expect(subject).to eq("the message content")
+    end
+
+    context "when the content is not present in the message" do
+      let(:message) do
+        {
+          data: 123
+        }
+      end
+
+      it "returns the message content" do
+        expect(subject).to be_nil
+      end
+    end
+  end
+
+  describe "#decoded_data" do
+    subject { log_entry.decoded_data }
+
+    it "returns the message" do
+      expect(subject).to eq(message)
+    end
+  end
+
+  describe "#previous_hash" do
+    subject { log_entry.previous_hash }
+
+    it "returns the chained hash of the last log entry for the election" do
+      expect(subject).to eq(election.log_entries.last.chained_hash)
+    end
+
+    context "when the election has cached log_entries" do
+      let(:last_log_entry) { create(:log_entry, election: election, message: message) }
+
+      before do
+        election.log_entries
+        last_log_entry
+      end
+
+      it "returns the last created log_entry chained hash" do
+        expect(subject).to eq(last_log_entry.chained_hash)
+      end
+    end
+
+    context "when the log entry is the first one for the election" do
+      let(:election) { build(:election, unique_id: "1234") }
+
+      it "returns the unique_id of the election" do
+        expect(subject).to eq("1234")
+      end
+    end
+  end
+
+  context "when saving the entry" do
+    subject { log_entry.save! }
+
+    it "stores the content hash" do
+      expect { subject }.to change(log_entry, :content_hash).from(nil)
+    end
+
+    it "stores the chained hash" do
+      expect { subject }.to change(log_entry, :chained_hash).from(nil)
+    end
+
+    it "stores the iat" do
+      expect { subject }.to change(log_entry, :iat).from(nil).to(iat)
+    end
+
+    it "stores the message_type" do
+      expect { subject }.to change(log_entry, :message_type).from(nil).to("type")
+    end
+
+    it "stores the author_unique_id" do
+      expect { subject }.to change(log_entry, :author_unique_id).from(nil).to("author")
+    end
+  end
+end

--- a/decidim-bulletin_board-app/spec/queries/get_election_spec.rb
+++ b/decidim-bulletin_board-app/spec/queries/get_election_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe "GetElection" do
               }
             end,
             verifiableResultsHash: "DEUES1tHaoxDH4FKS1NLB3SCTSbycqfAARsLrqL1wmE=",
-            verifiableResultsUrl: match(%r{/rails/active_storage/blobs/.*/verifiable-results.tar/})
+            verifiableResultsUrl: match(%r{/rails/active_storage/blobs/.*/verifiable-results\.tar})
           }
         }
       )

--- a/decidim-bulletin_board-app/spec/queries/get_election_spec.rb
+++ b/decidim-bulletin_board-app/spec/queries/get_election_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "GetElection" do
+  subject { DecidimBulletinBoardSchema.execute(query, context: context) }
+
+  let(:election) { create(:election) }
+  let(:context) { {} }
+  let(:query) do
+    <<~GQL
+      query GetElection {
+        election(uniqueId: "#{election.unique_id}") {
+          id
+          title
+          status
+          authority {
+            id
+            name
+            publicKey
+            type
+          }
+          trustees {
+            id
+            name
+            publicKey
+            type
+          }
+          logEntries {
+            messageId
+          }
+          verifiableResultsHash
+          verifiableResultsUrl
+        }
+      }
+    GQL
+  end
+
+  it "returns the elections information" do
+    expect(subject.deep_symbolize_keys).to include(
+      data: {
+        election: {
+          id: election.unique_id,
+          title: election.title.deep_symbolize_keys,
+          status: "created",
+          authority: {
+            id: election.authority.unique_id,
+            name: election.authority.name,
+            publicKey: election.authority.public_key.deep_symbolize_keys,
+            type: "Authority"
+          },
+          trustees: election.trustees.map do |trustee|
+            {
+              id: trustee.unique_id,
+              name: trustee.name,
+              publicKey: trustee.public_key.deep_symbolize_keys,
+              type: "Trustee"
+            }
+          end,
+          logEntries: election.log_entries.map do |log_entry|
+            {
+              messageId: log_entry.message_id
+            }
+          end,
+          verifiableResultsHash: nil,
+          verifiableResultsUrl: nil
+        }
+      }
+    )
+  end
+
+  context "when the election has published its results" do
+    let(:election) { create(:election, :results_published) }
+
+    it "returns the elections information with the verifiable results" do
+      expect(subject.deep_symbolize_keys).to include(
+        data: {
+          election: {
+            id: election.unique_id,
+            title: election.title.deep_symbolize_keys,
+            status: election.status,
+            authority: {
+              id: election.authority.unique_id,
+              name: election.authority.name,
+              publicKey: election.authority.public_key.deep_symbolize_keys,
+              type: "Authority"
+            },
+            trustees: election.trustees.map do |trustee|
+              {
+                id: trustee.unique_id,
+                name: trustee.name,
+                publicKey: trustee.public_key.deep_symbolize_keys,
+                type: "Trustee"
+              }
+            end,
+            logEntries: election.log_entries.map do |log_entry|
+              {
+                messageId: log_entry.message_id
+              }
+            end,
+            verifiableResultsHash: "DEUES1tHaoxDH4FKS1NLB3SCTSbycqfAARsLrqL1wmE=",
+            verifiableResultsUrl: match(%r{/rails/active_storage/blobs/.*/verifiable-results.tar/})
+          }
+        }
+      )
+    end
+  end
+end

--- a/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/authority/create_election.rb
+++ b/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/authority/create_election.rb
@@ -101,7 +101,7 @@ module Decidim
               sequence_order: index,
               vote_variation: question[:max_selections] == 1 ? "one_of_m" : "n_of_m",
               name: default_text(question[:title]),
-              number_elected: question[:answers].count,
+              number_elected: question[:max_selections],
               ballot_title: text(question[:title]),
               ballot_subtitle: text(question[:description]),
               ballot_selections: contest_answers(question)

--- a/decidim-bulletin_board-ruby/spec/decidim/bulletin_board/authority/create_election_spec.rb
+++ b/decidim-bulletin_board-ruby/spec/decidim/bulletin_board/authority/create_election_spec.rb
@@ -155,7 +155,7 @@ module Decidim
                                           sequence_order: 0,
                                           vote_variation: "one_of_m",
                                           name: "A question",
-                                          number_elected: 2,
+                                          number_elected: 1,
                                           ballot_title: { text: [{ language: "en", value: "A question" },
                                                                  { language: "es", value: "Una pregunta" }] },
                                           ballot_subtitle: { text: [{ language: "en", value: "A question description" },


### PR DESCRIPTION
This PR fixes the generation of the chained hashes. We were using the `decoded_data`, which is a ruby hash of hashes (in this case "hash" as dictionary or hashmap, not as string digest), instead of using the `signed_data`, which is a string and much more easy to be calculated equal on different environments.

It also avoid problems when retrieving the previous chained hash when log entries are cached within the election, that were happening during the seed process.

Finally, during the creation of an election it uses the `max_selections` value for the number of answers to select instead of using the total count of answers. 