### PR TITLE
Add download button for bulk votes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@
 /decidim-bulletin_board-app/storage/*
 !/decidim-bulletin_board-app/storage/.keep
 
+# Ignore generated votes file
+/decidim-bulletin_board-app/bulk_votes.csv
+
 /decidim-bulletin_board-app/public/assets
 /decidim-bulletin_board-app/.byebug_history
 

--- a/.gitignore
+++ b/.gitignore
@@ -22,9 +22,6 @@
 /decidim-bulletin_board-app/storage/*
 !/decidim-bulletin_board-app/storage/.keep
 
-# Ignore generated votes file
-/decidim-bulletin_board-app/bulk_votes.csv
-
 /decidim-bulletin_board-app/public/assets
 /decidim-bulletin_board-app/.byebug_history
 

--- a/decidim-bulletin_board-app/app/assets/stylesheets/sandbox/index.scss
+++ b/decidim-bulletin_board-app/app/assets/stylesheets/sandbox/index.scss
@@ -1,4 +1,5 @@
-.generate-votes-input-section {
+.generate-votes-input-section,
+.download-votes-button {
   display: none;
 }
 

--- a/decidim-bulletin_board-app/app/controllers/sandbox/elections_controller.rb
+++ b/decidim-bulletin_board-app/app/controllers/sandbox/elections_controller.rb
@@ -10,7 +10,8 @@ module Sandbox
     helper_method :election_results
     helper_method :default_bulk_votes_number
 
-    BULK_VOTES_FILE = "storage/bulk_votes.csv"
+    BULK_VOTES_FILE_NAME = "bulk_votes.csv"
+    BULK_VOTES_FILE_PATH = Rails.root.join(BULK_VOTES_FILE_NAME)
     DEFAULT_BULK_VOTES_NUMBER = 1000
 
     def index; end
@@ -44,6 +45,14 @@ module Sandbox
       number_of_votes_to_generate.times do
         file_client.cast_vote(election_id, SecureRandom.hex, random_encrypted_vote)
       end
+    end
+
+    def download_bulk_votes
+      send_file(
+        BULK_VOTES_FILE_PATH,
+        filename: BULK_VOTES_FILE_NAME,
+        type: "text/csv"
+      )
     end
 
     def end_vote
@@ -155,7 +164,7 @@ module Sandbox
     end
 
     def file_client
-      @file_client ||= Decidim::BulletinBoard::FileClient.new(BULK_VOTES_FILE, bulletin_board_settings)
+      @file_client ||= Decidim::BulletinBoard::FileClient.new(BULK_VOTES_FILE_PATH, bulletin_board_settings)
     end
 
     def bulletin_board_settings
@@ -186,7 +195,7 @@ module Sandbox
     end
 
     def delete_bulk_votes_file
-      File.delete(BULK_VOTES_FILE) if File.exist?(BULK_VOTES_FILE)
+      File.delete(BULK_VOTES_FILE_PATH) if File.exist?(BULK_VOTES_FILE_PATH)
     end
 
     def number_of_votes_to_generate

--- a/decidim-bulletin_board-app/app/controllers/sandbox/elections_controller.rb
+++ b/decidim-bulletin_board-app/app/controllers/sandbox/elections_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "test/private_keys"
+
 module Sandbox
   class ElectionsController < ApplicationController
     helper_method :elections, :election

--- a/decidim-bulletin_board-app/app/controllers/sandbox/elections_controller.rb
+++ b/decidim-bulletin_board-app/app/controllers/sandbox/elections_controller.rb
@@ -11,7 +11,7 @@ module Sandbox
     helper_method :default_bulk_votes_number
 
     BULK_VOTES_FILE_NAME = "bulk_votes.csv"
-    BULK_VOTES_FILE_PATH = Rails.root.join(BULK_VOTES_FILE_NAME)
+    BULK_VOTES_FILE_PATH = Rails.root.join("tmp", BULK_VOTES_FILE_NAME)
     DEFAULT_BULK_VOTES_NUMBER = 1000
 
     def index; end

--- a/decidim-bulletin_board-app/app/javascript/packs/sandbox/index.js
+++ b/decidim-bulletin_board-app/app/javascript/packs/sandbox/index.js
@@ -4,6 +4,7 @@ $(async () => {
   // UI Elements
   const $showInputButton = $(".show-input-button");
   const $generateVotesButton = $(".generate-votes-button");
+  const $downloadVotesButton = $(".download-votes-button");
 
   $showInputButton.on("click", (event) => {
     $(event.target).hide();
@@ -31,7 +32,10 @@ $(async () => {
         "X-CSRF-Token": $("meta[name=csrf-token]").attr("content"),
       },
     })
-      .done(() => $(event.target).html(`${votesToGenerate} votes generated!`))
+      .done(() => {
+        $(event.target).closest(".generate-votes-input-section").hide();
+        $downloadVotesButton.css("display", "inline");
+      })
       .fail(() => $(event.target).html(`Failed, retry!`));
   });
 });

--- a/decidim-bulletin_board-app/app/views/sandbox/elections/index.html.erb
+++ b/decidim-bulletin_board-app/app/views/sandbox/elections/index.html.erb
@@ -41,6 +41,7 @@
                 <input class="generate-votes-input" type="number" placeholder="How many votes?" value="<%= default_bulk_votes_number %>"/>
                 <button class="generate-votes-button">Generate votes</button>
               </div>
+              <%= link_to "Download votes", download_bulk_votes_sandbox_election_path(election), class: "download-votes-button", download: 'bulk_votes.csv' %>
             <% elsif election.vote_ended? %>
               <%= link_to "Start tally", start_tally_sandbox_election_path(election) %>
             <% elsif election.tally? %>

--- a/decidim-bulletin_board-app/config/environments/development.rb
+++ b/decidim-bulletin_board-app/config/environments/development.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "test/private_keys"
-
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/decidim-bulletin_board-app/config/routes.rb
+++ b/decidim-bulletin_board-app/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
           get :vote
           post :vote
           post :generate_bulk_votes
+          get :download_bulk_votes
           get :end_vote
           get :start_tally
           get :tally

--- a/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/graphql/file_adapter.rb
+++ b/decidim-bulletin_board-ruby/lib/decidim/bulletin_board/graphql/file_adapter.rb
@@ -18,7 +18,7 @@ module Decidim
           body["variables"] = variables if variables.any?
           body["operationName"] = operation_name if operation_name
 
-          CSV.open(file_name, "a+") do |csv|
+          CSV.open(file_name, "a+", col_sep: ";") do |csv|
             csv << [JSON.generate(body), context[:headers]["Authorization"]]
           end
 


### PR DESCRIPTION
Adds the possibility to download the generated votes CSV from a button in the sandbox.

**Disclaimer**: Heroku timeouts requests over 30s, so it's not possible to generate more than ~1000 votes with the current method.
For the moment I'll just manually merge several files, but if we want to automatise the load test we'll need to move the file generation to a background job.

[](https://user-images.githubusercontent.com/5033945/110104401-67d5b000-7da7-11eb-8f70-2c88b18f1e53.mov)

Also: moves `require "test/private_keys"` to the sandbox controller to have it available in all environments

