### PR TITLE
Fix references to removed master branch

### DIFF
--- a/.github/workflows/app-workflow.yml
+++ b/.github/workflows/app-workflow.yml
@@ -6,7 +6,8 @@ on:
       - "decidim-bulletin_board-app/**"
   push:
     branches:
-      - master
+      - develop
+      - main
 
 env:
   CI: "true"

--- a/.github/workflows/ruby-workflow.yml
+++ b/.github/workflows/ruby-workflow.yml
@@ -6,7 +6,8 @@ on:
       - "decidim-bulletin_board-ruby/**"
   push:
     branches:
-      - master
+      - develop
+      - main
 
 env:
   CI: "true"

--- a/.github/workflows/verifier-workflow.yml
+++ b/.github/workflows/verifier-workflow.yml
@@ -6,7 +6,8 @@ on:
       - "verifier/**"
   push:
     branches:
-      - master
+      - develop
+      - main
 
 env:
   CI: "true"

--- a/.github/workflows/voting-scheme-dummy-js-adapter-workflow.yml
+++ b/.github/workflows/voting-scheme-dummy-js-adapter-workflow.yml
@@ -6,7 +6,8 @@ on:
       - "voting_schemes/dummy/js-adapter/**"
   push:
     branches:
-      - master
+      - develop
+      - main
 
 env:
   CI: "true"

--- a/.github/workflows/voting-scheme-election_guard-js-adapter-workflow.yml
+++ b/.github/workflows/voting-scheme-election_guard-js-adapter-workflow.yml
@@ -6,7 +6,8 @@ on:
       - "voting_schemes/election_guard/js-adapter/**"
   push:
     branches:
-      - master
+      - develop
+      - main
 
 env:
   CI: "true"

--- a/.github/workflows/voting-scheme-election_guard-python-wrapper-workflow.yml
+++ b/.github/workflows/voting-scheme-election_guard-python-wrapper-workflow.yml
@@ -6,7 +6,8 @@ on:
       - "voting_schemes/election_guard/python-wrapper/**"
   push:
     branches:
-      - master
+      - develop
+      - main
 
 env:
   CI: "true"

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 This repository follows the monorepo pattern and includes the following projects:
 
-- **decidim-bulletin_board-app**: A Ruby on Rails application that contains the Bulletin Board service. You can check the project details [here](https://github.com/decidim/decidim-bulletin-board/blob/master/decidim-bulletin_board-app/README.md).
-- **decidim-bulletin_board-ruby**: A Ruby gem that can be included in other applications to interact with the Bulletin Board application. You can check the project details [here](https://github.com/decidim/decidim-bulletin-board/blob/master/decidim-bulletin_board-ruby/README.md).
+- **decidim-bulletin_board-app**: A Ruby on Rails application that contains the Bulletin Board service. You can check the project details [here](https://github.com/decidim/decidim-bulletin-board/blob/develop/decidim-bulletin_board-app/README.md).
+- **decidim-bulletin_board-ruby**: A Ruby gem that can be included in other applications to interact with the Bulletin Board application. You can check the project details [here](https://github.com/decidim/decidim-bulletin-board/blob/develop/decidim-bulletin_board-ruby/README.md).
 
 ## License
 

--- a/decidim-bulletin_board-app/.rubocop.yml
+++ b/decidim-bulletin_board-app/.rubocop.yml
@@ -1,4 +1,4 @@
-inherit_from: https://raw.githubusercontent.com/decidim/decidim/master/.rubocop.yml
+inherit_from: https://raw.githubusercontent.com/decidim/decidim/develop/.rubocop.yml
 
 AllCops:
   Include:

--- a/docs/modules/develop/pages/environment.adoc
+++ b/docs/modules/develop/pages/environment.adoc
@@ -1,5 +1,5 @@
 = Development environment
 
-To start working with the Bulletin Board you will need to install all the dependencies for the server. These are explained in the https://github.com/decidim/decidim-bulletin_board/blob/master/README.md[README file of the web application]. This server will include test data that can be used by Decidim or the elections sandbox to test the different parts of the system.
+To start working with the Bulletin Board you will need to install all the dependencies for the server. These are explained in the https://github.com/decidim/decidim-bulletin_board/blob/main/README.md[README file of the web application]. This server will include test data that can be used by Decidim or the elections sandbox to test the different parts of the system.
 
 Also, this application includes Visual Studio Code Dev Containers to simplify the environment setup.


### PR DESCRIPTION
Some github actions and documentation files were linking to the `master` branch, which was renamed to `main` some time ago. In particular, code coverage was not being calculated because of this. This PR fixes that.