### PR TITLE
Generate load test stats

### DIFF
--- a/decidim-bulletin_board-app/app/commands/sandbox/generate_load_test_stats.rb
+++ b/decidim-bulletin_board-app/app/commands/sandbox/generate_load_test_stats.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+module Sandbox
+  # A command with all the business logic to create the statistics of a load test
+  class GenerateLoadTestStats < Rectify::Command
+    STATS_OUTPUT_FILE_NAME = "load_test_stats.json"
+    STATS_OUTPUT_FILE_PATH = Rails.root.join("tmp", STATS_OUTPUT_FILE_NAME)
+
+    # Public: Initializes the command.
+    #
+    # election - The election to generate the stats for
+    # earliest_vote_time - The time of the first vote to consider
+    # latest_vote_time - The time of the last vote to consider
+    def initialize(election_id, earliest_vote_time = 2.hours.ago, latest_vote_time = Time.zone.now)
+      @election_id = election_id
+      @earliest_vote_time = earliest_vote_time.is_a?(String) ? Time.zone.parse(earliest_vote_time) : earliest_vote_time
+      @latest_vote_time = latest_vote_time.is_a?(String) ? Time.zone.parse(latest_vote_time) : latest_vote_time
+    end
+
+    # Executes the command.
+    def call
+      stats = generate_stats
+      clear_existing_file
+      write_stats_to_file(stats)
+    end
+
+    private
+
+    attr_reader :election_id, :election, :earliest_vote_time, :latest_vote_time
+
+    def generate_stats
+      {
+        votes: votes_stats,
+        aggregates: aggregate_stats
+      }
+    end
+
+    def votes_stats
+      @votes_stats ||= pertinent_pending_messages.map do |pending_message|
+        {
+          message_id: pending_message.id,
+          status: pending_message.status,
+          created: pending_message.created_at,
+          updated: pending_message.updated_at,
+          processing_time: (pending_message.updated_at - pending_message.created_at) * 1000
+        }
+      end
+    end
+
+    def aggregate_stats
+      {
+        votes_number: votes_number,
+        accepted_votes_number: accepted_votes_number,
+        accepted_votes_percentage: accepted_votes_number * 100 / votes_number,
+        total_processing_time: total_processing_time,
+        avg_processing_time: total_processing_time / votes_number,
+        total_running_time: total_running_time
+      }
+    end
+
+    def votes_number
+      @votes_number ||= pertinent_pending_messages.size
+    end
+
+    def accepted_votes_number
+      @accepted_votes_number ||= pertinent_pending_messages.where(status: "accepted").size
+    end
+
+    def total_running_time
+      @total_running_time ||= (pertinent_pending_messages.max_by(&:updated_at)[:updated_at] - pertinent_pending_messages.min_by(&:created_at)[:created_at]) * 1000
+    end
+
+    def total_processing_time
+      @total_processing_time ||= (votes_stats.sum { |vote| vote[:processing_time] })
+    end
+
+    def pertinent_pending_messages
+      @pertinent_pending_messages ||= PendingMessage
+                                      .where(election_id: election_id)
+                                      .where("created_at >= :date", date: earliest_vote_time)
+                                      .where("created_at <= :date", date: latest_vote_time)
+    end
+
+    def clear_existing_file
+      File.delete(STATS_OUTPUT_FILE_PATH) if File.exist?(STATS_OUTPUT_FILE_PATH)
+    end
+
+    def write_stats_to_file(stats)
+      File.open(STATS_OUTPUT_FILE_PATH, "w") do |f|
+        f.puts stats.to_json
+      end
+    end
+  end
+end

--- a/decidim-bulletin_board-app/app/controllers/sandbox/elections_controller.rb
+++ b/decidim-bulletin_board-app/app/controllers/sandbox/elections_controller.rb
@@ -55,6 +55,14 @@ module Sandbox
       )
     end
 
+    def load_test_stats
+      Sandbox::GenerateLoadTestStats.new(election.id).call
+      send_file(
+        Sandbox::GenerateLoadTestStats::STATS_OUTPUT_FILE_PATH,
+        type: "application/json"
+      )
+    end
+
     def end_vote
       bulletin_board_client.end_vote(election_id)
       go_back

--- a/decidim-bulletin_board-app/app/views/sandbox/elections/index.html.erb
+++ b/decidim-bulletin_board-app/app/views/sandbox/elections/index.html.erb
@@ -36,7 +36,7 @@
             <% elsif election.vote? %>
               <%= link_to "Vote", vote_sandbox_election_path(election) %> |
               <%= link_to "End vote", end_vote_sandbox_election_path(election) %>  |
-              <%= link_to "Load test stats", load_test_stats_sandbox_election_path(election), download: "load_test_stats.json" %>  |
+              <%= link_to "Load test stats", load_test_stats_sandbox_election_path(election), download: Sandbox::GenerateLoadTestStats::STATS_OUTPUT_FILE_NAME %>  |
               <button class="show-input-button"> Generate bulk votes </button>
               <div class="generate-votes-input-section">
                 <input class="generate-votes-input" type="number" placeholder="How many votes?" value="<%= default_bulk_votes_number %>"/>

--- a/decidim-bulletin_board-app/app/views/sandbox/elections/index.html.erb
+++ b/decidim-bulletin_board-app/app/views/sandbox/elections/index.html.erb
@@ -36,6 +36,7 @@
             <% elsif election.vote? %>
               <%= link_to "Vote", vote_sandbox_election_path(election) %> |
               <%= link_to "End vote", end_vote_sandbox_election_path(election) %>  |
+              <%= link_to "Load test stats", load_test_stats_sandbox_election_path(election), download: "load_test_stats.json" %>  |
               <button class="show-input-button"> Generate bulk votes </button>
               <div class="generate-votes-input-section">
                 <input class="generate-votes-input" type="number" placeholder="How many votes?" value="<%= default_bulk_votes_number %>"/>

--- a/decidim-bulletin_board-app/config/routes.rb
+++ b/decidim-bulletin_board-app/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
           post :vote
           post :generate_bulk_votes
           get :download_bulk_votes
+          get :load_test_stats
           get :end_vote
           get :start_tally
           get :tally


### PR DESCRIPTION
Enables the user to extrapolate some stats from the last load test executed.

Notice that, although the `Sandbox::LoadTestStats` command is prepared to receive a timeframe to run the stats on, for the moment we're only considering the last 2 hours. In the future that could be a user input.

[](https://user-images.githubusercontent.com/5033945/110319548-5989cd00-800f-11eb-84b9-3763236aff11.mov)

