### PR TITLE
Move bulk vote generation to background job

### DIFF
--- a/decidim-bulletin_board-app/app/controllers/sandbox/elections_controller.rb
+++ b/decidim-bulletin_board-app/app/controllers/sandbox/elections_controller.rb
@@ -8,7 +8,7 @@ module Sandbox
     helper_method :bulletin_board_server, :authority_slug, :authority_public_key
     helper_method :base_vote, :random_voter_id
     helper_method :election_results
-    helper_method :default_bulk_votes_number
+    helper_method :default_bulk_votes_number, :bulk_votes_file_name, :bulk_votes_file_exists?, :generated_votes_number
 
     BULK_VOTES_FILE_NAME = "bulk_votes.csv"
     BULK_VOTES_FILE_PATH = Rails.root.join("tmp", BULK_VOTES_FILE_NAME)
@@ -42,12 +42,12 @@ module Sandbox
     def generate_bulk_votes
       delete_bulk_votes_file
 
-      number_of_votes_to_generate.times do
-        file_client.cast_vote(election_id, SecureRandom.hex, random_encrypted_vote)
-      end
+      GenerateVotesJob.perform_later(number_of_votes_to_generate, election.id, BULK_VOTES_FILE_PATH.to_s, bulletin_board_settings_hash)
     end
 
     def download_bulk_votes
+      return head(:not_foud) unless bulk_votes_file_exists?
+
       send_file(
         BULK_VOTES_FILE_PATH,
         filename: BULK_VOTES_FILE_NAME,
@@ -168,7 +168,11 @@ module Sandbox
     end
 
     def bulletin_board_settings
-      @bulletin_board_settings ||= OpenStruct.new(
+      @bulletin_board_settings ||= OpenStruct.new(bulletin_board_settings_hash)
+    end
+
+    def bulletin_board_settings_hash
+      @bulletin_board_settings_hash ||= {
         bulletin_board_server: api_endpoint_url,
         bulletin_board_public_key: BulletinBoard.public_key,
         authority_api_key: authority.api_key,
@@ -177,7 +181,7 @@ module Sandbox
         scheme_name: params.dig(:election, :voting_scheme_name) || "dummy",
         quorum: 2,
         number_of_trustees: 3
-      )
+      }
     end
 
     def base_vote
@@ -195,7 +199,7 @@ module Sandbox
     end
 
     def delete_bulk_votes_file
-      File.delete(BULK_VOTES_FILE_PATH) if File.exist?(BULK_VOTES_FILE_PATH)
+      File.delete(BULK_VOTES_FILE_PATH) if bulk_votes_file_exists?
     end
 
     def number_of_votes_to_generate
@@ -206,32 +210,16 @@ module Sandbox
       DEFAULT_BULK_VOTES_NUMBER
     end
 
-    def random_encrypted_vote
-      {
-        ballot_style: "ballot-style",
-        contests: election.manifest[:description][:contests].map do |contest|
-          current_selections = 0
-          {
-            object_id: contest[:object_id],
-            ballot_selections: contest[:ballot_selections].map do |ballot_selection|
-              answer = random_answer(current_selections > contest[:number_elected])
-              current_selections += answer
-              {
-                object_id: ballot_selection[:object_id],
-                ciphertext: answer + (rand * 500).floor * joint_election_key
-              }
-            end
-          }
-        end
-      }.to_json
+    def bulk_votes_file_name
+      BULK_VOTES_FILE_NAME
     end
 
-    def random_answer(max_reached)
-      max_reached ? 0 : rand(0..1)
+    def bulk_votes_file_exists?
+      File.exist?(BULK_VOTES_FILE_PATH)
     end
 
-    def joint_election_key
-      @joint_election_key ||= JSON.parse(election.log_entries.where(message_type: "end_key_ceremony").last.decoded_data["content"])["joint_election_key"]
+    def generated_votes_number
+      `wc -l "#{BULK_VOTES_FILE_PATH}"`.strip.split(" ")[0].to_i
     end
   end
 end

--- a/decidim-bulletin_board-app/app/javascript/packs/sandbox/index.js
+++ b/decidim-bulletin_board-app/app/javascript/packs/sandbox/index.js
@@ -4,7 +4,6 @@ $(async () => {
   // UI Elements
   const $showInputButton = $(".show-input-button");
   const $generateVotesButton = $(".generate-votes-button");
-  const $downloadVotesButton = $(".download-votes-button");
 
   $showInputButton.on("click", (event) => {
     $(event.target).hide();
@@ -18,7 +17,7 @@ $(async () => {
     const votesToGenerate = $(event.target)
       .siblings(".generate-votes-input")
       .val();
-    $(event.target).html(`Generating ${votesToGenerate} votes...`);
+    $(event.target).html(`Launching generation...`);
     $(event.target).prop("disabled", true);
 
     $.ajax({
@@ -32,10 +31,7 @@ $(async () => {
         "X-CSRF-Token": $("meta[name=csrf-token]").attr("content"),
       },
     })
-      .done(() => {
-        $(event.target).closest(".generate-votes-input-section").hide();
-        $downloadVotesButton.css("display", "inline");
-      })
+      .done(() => location.reload())
       .fail(() => $(event.target).html(`Failed, retry!`));
   });
 });

--- a/decidim-bulletin_board-app/app/jobs/sandbox/generate_votes_job.rb
+++ b/decidim-bulletin_board-app/app/jobs/sandbox/generate_votes_job.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Sandbox
+  class GenerateVotesJob < ApplicationJob
+    def perform(number_of_votes, election_id, file_path, client_settings = {})
+      @election_id = election_id
+      client = Decidim::BulletinBoard::FileClient.new(file_path, OpenStruct.new(client_settings))
+
+      number_of_votes.times do
+        client.cast_vote(election_id, SecureRandom.hex, random_encrypted_vote)
+      end
+    end
+
+    attr_reader :election_id
+
+    private
+
+    def random_encrypted_vote
+      {
+        ballot_style: "ballot-style",
+        contests: election.manifest[:description][:contests].map do |contest|
+          current_selections = 0
+          {
+            object_id: contest[:object_id],
+            ballot_selections: contest[:ballot_selections].map do |ballot_selection|
+              answer = random_answer(current_selections > contest[:number_elected])
+              current_selections += answer
+              {
+                object_id: ballot_selection[:object_id],
+                ciphertext: answer + (rand * 500).floor * joint_election_key
+              }
+            end
+          }
+        end
+      }.to_json
+    end
+
+    def random_answer(max_reached)
+      max_reached ? 0 : rand(0..1)
+    end
+
+    def joint_election_key
+      @joint_election_key ||= JSON.parse(election.log_entries.where(message_type: "end_key_ceremony").last.decoded_data["content"])["joint_election_key"]
+    end
+
+    def election
+      @election ||= Election.find_by(id: election_id)
+    end
+  end
+end

--- a/decidim-bulletin_board-app/app/views/sandbox/elections/index.html.erb
+++ b/decidim-bulletin_board-app/app/views/sandbox/elections/index.html.erb
@@ -41,7 +41,9 @@
                 <input class="generate-votes-input" type="number" placeholder="How many votes?" value="<%= default_bulk_votes_number %>"/>
                 <button class="generate-votes-button">Generate votes</button>
               </div>
-              <%= link_to "Download votes", download_bulk_votes_sandbox_election_path(election), class: "download-votes-button", download: 'bulk_votes.csv' %>
+              <% if bulk_votes_file_exists? %>
+                <%= link_to "Download #{generated_votes_number} votes", download_bulk_votes_sandbox_election_path(election), download: bulk_votes_file_name %>
+              <% end %>
             <% elsif election.vote_ended? %>
               <%= link_to "Start tally", start_tally_sandbox_election_path(election) %>
             <% elsif election.tally? %>


### PR DESCRIPTION
Moves the bulk votes generation process to a background job in order to avoid long HTTP requests when generating loads of votes.

To give the user a clue when the job has finished, we show the number of votes currently generated at every page load.



[](https://user-images.githubusercontent.com/5033945/110443193-f1dd8b80-80bb-11eb-93fb-e2fa3b5be5d9.mov)
