### PR TITLE
Remove unused cors settings

### DIFF
--- a/decidim-bulletin_board-app/config/initializers/cors.rb
+++ b/decidim-bulletin_board-app/config/initializers/cors.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
-return if Rails.application.config.settings.cors_origin_allowed.blank?
-
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins Rails.application.config.settings.cors_origin_allowed
+    origins "*"
     resource "*", headers: :any, methods: [:get, :post, :patch, :put]
   end
 end

--- a/decidim-bulletin_board-app/config/settings.yml
+++ b/decidim-bulletin_board-app/config/settings.yml
@@ -2,7 +2,6 @@ default: &default
   iat_expiration_minutes: 60
   create_election:
     hours_before: 2
-  cors_origin_allowed: "*"
 
 development:
   <<: *default
@@ -12,4 +11,3 @@ test:
 
 production:
   <<: *default
-  cors_origin_allowed: <%= ENV["CORS_ORIGIN_ALLOWED"] %>

--- a/docs/modules/configure/pages/environment_variables.adoc
+++ b/docs/modules/configure/pages/environment_variables.adoc
@@ -6,9 +6,6 @@ We try to let most of the things defined through Environment Variables, as https
 |===
 |Name |Value
 
-|CORS_ORIGIN_ALLOWED
-|The domains allowed to access to the API. Use `*` for public Bulletin Boards.
-
 |DATABASE_URL
 |Connection string for the Postgres database
 


### PR DESCRIPTION
It doesn't make sense to have a setting for allowed CORS domains. In the future we could add all the authorities domains, but at the moment this PR sets that value to `*`.