### PR TITLE
Consistent usage of slug instead of unique_id

### DIFF
--- a/bulletin_board/server/app/commands/concerns/log_entry_command.rb
+++ b/bulletin_board/server/app/commands/concerns/log_entry_command.rb
@@ -78,7 +78,7 @@ module LogEntryCommand
           election.unique_id,
           response_message.delete("message_type"),
           :bulletin_board,
-          BulletinBoard.unique_id
+          BulletinBoard.slug
         )
 
         LogEntry.create!(

--- a/bulletin_board/server/app/models/authority.rb
+++ b/bulletin_board/server/app/models/authority.rb
@@ -3,6 +3,8 @@
 class Authority < Client
   has_many :elections
 
+  alias_attribute :slug, :unique_id
+
   def authority?
     true
   end

--- a/bulletin_board/server/app/models/bulletin_board.rb
+++ b/bulletin_board/server/app/models/bulletin_board.rb
@@ -68,7 +68,7 @@ class BulletinBoard
       true
     end
 
-    def unique_id
+    def slug
       name.parameterize
     end
 

--- a/bulletin_board/server/package-lock.json
+++ b/bulletin_board/server/package-lock.json
@@ -3256,6 +3256,7 @@
         "@babel/traverse": "7.12.12",
         "@babel/types": "7.12.12",
         "@graphql-tools/utils": "^7.0.0",
+        "@vue/compiler-sfc": "^3.0.4",
         "tslib": "~2.1.0"
       },
       "optionalDependencies": {
@@ -5402,6 +5403,7 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
+        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -5522,6 +5524,7 @@
       "integrity": "sha512-gnB85c3MGC7Nm9I/FkiasNBOKjOiO1RNuXXarQms37q4QMpWdlbBgD/VnOStA2faG1dpXMv31RFApjX1/QdgWQ==",
       "dev": true,
       "dependencies": {
+        "colors": "^1.1.2",
         "object-assign": "^4.1.0",
         "string-width": "^4.2.0"
       },
@@ -15057,6 +15060,7 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
+        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",

--- a/bulletin_board/server/spec/factories/electionguard.rb
+++ b/bulletin_board/server/spec/factories/electionguard.rb
@@ -47,7 +47,7 @@ end
 def create_election_step(election, evaluator)
   create_election_message = CREATE_ELECTION_MESSAGE.deep_dup
   create_election_message["iat"] = Time.current.to_i
-  create_election_message["message_id"] = "#{election.unique_id}.create_election+a.#{election.authority.unique_id}"
+  create_election_message["message_id"] = "#{election.unique_id}.create_election+a.#{election.authority.slug}"
 
   evaluator.trustees_plus_keys.map(&:first).each_with_index do |trustee, order|
     create_election_message["trustees"][order]["public_key"] = trustee.public_key
@@ -60,7 +60,7 @@ end
 def start_key_ceremony_step(election, evaluator)
   start_key_ceremony_message = {}
   start_key_ceremony_message["iat"] = Time.current.to_i
-  start_key_ceremony_message["message_id"] = "#{election.unique_id}.start_key_ceremony+a.#{election.authority.unique_id}"
+  start_key_ceremony_message["message_id"] = "#{election.unique_id}.start_key_ceremony+a.#{election.authority.slug}"
 
   election.log_entries << FactoryBot.build(:log_entry, election: election, client: election.authority,
                                                        private_key: evaluator.authority_private_key, message: start_key_ceremony_message)
@@ -71,11 +71,11 @@ def trustee_election_keys_step(election, evaluator)
     trustee, private_key = evaluator.trustees_plus_keys[order]
     content = JSON.parse(message["content"])
 
-    raise "Mismatched trustee #{trustee.unique_id} vs msg #{content["public_key_set"]["owner_id"]}" if trustee.unique_id != content["public_key_set"]["owner_id"]
+    raise "Mismatched trustee #{trustee.slug} vs msg #{content["public_key_set"]["owner_id"]}" if trustee.slug != content["public_key_set"]["owner_id"]
 
     trustee_public_key_message = message.deep_dup
     trustee_public_key_message["iat"] = Time.current.to_i
-    trustee_public_key_message["message_id"] = "#{election.unique_id}.key_ceremony.trustee_election_keys+t.#{trustee.unique_id}"
+    trustee_public_key_message["message_id"] = "#{election.unique_id}.key_ceremony.trustee_election_keys+t.#{trustee.slug}"
 
     election.log_entries << FactoryBot.build(:log_entry, election: election, client: trustee,
                                                          private_key: private_key, message: trustee_public_key_message)
@@ -86,11 +86,11 @@ def trustee_partial_election_keys_step(election, evaluator)
   TRUSTEE_PARTIAL_ELECTION_KEYS_MESSAGES.each_with_index do |message, order|
     trustee, private_key = evaluator.trustees_plus_keys[order]
 
-    raise "Mismatched trustee #{trustee.unique_id} vs msg #{JSON.parse(message["content"])["guardian_id"]}" if trustee.unique_id != JSON.parse(message["content"])["guardian_id"]
+    raise "Mismatched trustee #{trustee.slug} vs msg #{JSON.parse(message["content"])["guardian_id"]}" if trustee.slug != JSON.parse(message["content"])["guardian_id"]
 
     trustee_partial_public_key_message = message.deep_dup
     trustee_partial_public_key_message["iat"] = Time.current.to_i
-    trustee_partial_public_key_message["message_id"] = "#{election.unique_id}.key_ceremony.trustee_partial_election_keys+t.#{trustee.unique_id}"
+    trustee_partial_public_key_message["message_id"] = "#{election.unique_id}.key_ceremony.trustee_partial_election_keys+t.#{trustee.slug}"
 
     election.log_entries << FactoryBot.build(:log_entry, election: election, client: trustee,
                                                          private_key: private_key, message: trustee_partial_public_key_message)
@@ -101,11 +101,11 @@ def trustee_verification_step(election, evaluator)
   TRUSTEE_VERIFICATION_MESSAGES.each_with_index do |message, order|
     trustee, private_key = evaluator.trustees_plus_keys[order]
 
-    raise "Mismatched trustee #{trustee.unique_id} vs msg #{JSON.parse(message["content"])["guardian_id"]}" if trustee.unique_id != JSON.parse(message["content"])["guardian_id"]
+    raise "Mismatched trustee #{trustee.slug} vs msg #{JSON.parse(message["content"])["guardian_id"]}" if trustee.slug != JSON.parse(message["content"])["guardian_id"]
 
     trustee_verification_message = message.deep_dup
     trustee_verification_message["iat"] = Time.current.to_i
-    trustee_verification_message["message_id"] = "#{election.unique_id}.key_ceremony.trustee_verification+t.#{trustee.unique_id}"
+    trustee_verification_message["message_id"] = "#{election.unique_id}.key_ceremony.trustee_verification+t.#{trustee.slug}"
 
     election.log_entries << FactoryBot.build(:log_entry, election: election, client: trustee,
                                                          private_key: private_key, message: trustee_verification_message)
@@ -115,7 +115,7 @@ end
 def end_key_ceremony_step(election, _evaluator)
   end_key_ceremony_message = END_KEY_CEREMONY_MESSAGE.deep_dup
   end_key_ceremony_message["iat"] = Time.current.to_i
-  end_key_ceremony_message["message_id"] = "#{election.unique_id}.end_key_ceremony+b.#{BulletinBoard.unique_id}"
+  end_key_ceremony_message["message_id"] = "#{election.unique_id}.end_key_ceremony+b.#{BulletinBoard.slug}"
 
   election.log_entries << FactoryBot.build(:log_entry, election: election, bulletin_board: true,
                                                        signed_data: BulletinBoard.sign(end_key_ceremony_message), message: end_key_ceremony_message)

--- a/bulletin_board/server/spec/factories/messages.rb
+++ b/bulletin_board/server/spec/factories/messages.rb
@@ -75,7 +75,7 @@ FactoryBot.define do
         authority { Authority.first }
       end
 
-      slug { authority.unique_id }
+      slug { authority.slug }
       name { authority.name }
       public_key { authority.public_key }
     end
@@ -166,7 +166,7 @@ FactoryBot.define do
         authority { Authority.first }
       end
 
-      message_id { "#{election.unique_id}.start_key_ceremony+a.#{authority.unique_id}" }
+      message_id { "#{election.unique_id}.start_key_ceremony+a.#{authority.slug}" }
     end
 
     factory :key_ceremony_message, parent: :message do
@@ -207,7 +207,7 @@ FactoryBot.define do
         election { create(:election) }
       end
 
-      message_id { "#{election.unique_id}.end_key_ceremony+b.#{BulletinBoard.unique_id}" }
+      message_id { "#{election.unique_id}.end_key_ceremony+b.#{BulletinBoard.slug}" }
       content { build(:joint_election_message_content, *content_traits, election: election).to_json }
     end
 
@@ -225,7 +225,7 @@ FactoryBot.define do
         authority { Authority.first }
       end
 
-      message_id { "#{election.unique_id}.start_vote+a.#{authority.unique_id}" }
+      message_id { "#{election.unique_id}.start_vote+a.#{authority.slug}" }
     end
 
     factory :vote_message, parent: :message do
@@ -272,7 +272,7 @@ FactoryBot.define do
         authority { Authority.first }
       end
 
-      message_id { "#{election.unique_id}.end_vote+a.#{authority.unique_id}" }
+      message_id { "#{election.unique_id}.end_vote+a.#{authority.slug}" }
     end
 
     factory :start_tally_message, parent: :message do
@@ -281,7 +281,7 @@ FactoryBot.define do
         authority { Authority.first }
       end
 
-      message_id { "#{election.unique_id}.start_tally+a.#{authority.unique_id}" }
+      message_id { "#{election.unique_id}.start_tally+a.#{authority.slug}" }
     end
 
     factory :tally_cast_message, parent: :message do
@@ -290,7 +290,7 @@ FactoryBot.define do
         joint_election_key { Test::Elections.joint_election_key }
       end
 
-      message_id { "#{election.unique_id}.tally.cast+b.#{BulletinBoard.unique_id}" }
+      message_id { "#{election.unique_id}.tally.cast+b.#{BulletinBoard.slug}" }
       content { Test::Elections.build_cast(election) { Random.random_number(99) + Random.random_number(13) * joint_election_key }.to_json }
     end
 
@@ -345,7 +345,7 @@ FactoryBot.define do
         tally_cast { Test::Elections.build_cast(election) { Random.random_number(99) + Random.random_number(13) * joint_election_key } }
       end
 
-      message_id { "#{election.unique_id}.end_tally+b.#{BulletinBoard.unique_id}" }
+      message_id { "#{election.unique_id}.end_tally+b.#{BulletinBoard.slug}" }
 
       after(:build) do |message, evaluator|
         message[:results] = evaluator.tally_cast.map do |question, answers|
@@ -368,7 +368,7 @@ FactoryBot.define do
         authority { Authority.first }
       end
 
-      message_id { "#{election.unique_id}.publish_results+a.#{authority.unique_id}" }
+      message_id { "#{election.unique_id}.publish_results+a.#{authority.slug}" }
     end
   end
 end


### PR DESCRIPTION
This PR renames the `unique_id` for the `BulletinBoard` to `slug` and sets an `alias` for the `authority.unique_id` to be `authority.slug`. 

It also updates the `electionguard` factories with the latest changes for the `trustee.unique_id`.