### PR TITLE
Fix e2e flaky test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ help:
 	@echo 'Releasing packages:'
 	@echo '  release - Bump versions, commit and push changes to the repository and release gems. Requires clean repository and VERSION set.'
 
-.PHONY: clean install build test release
+.PHONY: clean install build serve test release
 
 # CONSTANTS
 
@@ -143,6 +143,9 @@ test_bulletin_board_server:
 
 bump_version_bulletin_board_server:
 	cd ${BULLETIN_BOARD_SERVER_PATH} && bundle
+
+serve:
+	cd ${BULLETIN_BOARD_SERVER_PATH} && bundle exec rails s
 
 # BULLETIN BOARD CLIENT
 

--- a/bulletin_board/server/cypress/integration/sandbox/election.page.js
+++ b/bulletin_board/server/cypress/integration/sandbox/election.page.js
@@ -298,9 +298,6 @@ export class ElectionPage {
     cy.findByText("Perform tally").click().should("not.exist");
     cy.findByText(`Tally for ${electionTitle}`).should("be.visible");
 
-    // Wait a decent amount of time to make sure electionguard is loaded.
-    cy.wait(15_000);
-
     trustees.forEach(({ unique_id, name }) => {
       cy.findByText(name)
         .parent("tr")
@@ -308,6 +305,9 @@ export class ElectionPage {
           cy.findByText("Start").click({
             timeout: 120_000,
           });
+
+          // Wait a decent amount of time to make sure electionguard is loaded.
+          cy.wait(15_000);
 
           // Ensure that the button is present before starting to upload the trustee state
           cy.findByText("Restore").should("be.visible");

--- a/bulletin_board/server/cypress/integration/sandbox/election.page.js
+++ b/bulletin_board/server/cypress/integration/sandbox/election.page.js
@@ -223,7 +223,7 @@ export class ElectionPage {
       });
     cy.findByText("Encrypt vote").should("be.visible").click();
     cy.findByText("Cast vote", {
-      timeout: 120_000,
+      timeout: 180_000,
     })
       .should("be.visible")
       .click();


### PR DESCRIPTION
In this PR I solve a few problems with the flaky tests (I hope 🤞 ). When performing the tally I'm waiting a few seconds before each trustee starts the process. I also increased the timeout of the cast vote.