### PR TITLE
Wait some time before casting the vote while running e2e test suite

### DIFF
--- a/bulletin_board/server/cypress/integration/sandbox/election.page.js
+++ b/bulletin_board/server/cypress/integration/sandbox/election.page.js
@@ -221,6 +221,10 @@ export class ElectionPage {
       .then((vote) => {
         this.castedVotes.push(Object.values(JSON.parse(vote)).flat());
       });
+
+    // Wait a decent amount of time to make sure electionguard is loaded.
+    cy.wait(15_000);
+
     cy.findByText("Encrypt vote").should("be.visible").click();
     cy.findByText("Cast vote", {
       timeout: 180_000,


### PR DESCRIPTION
This is another attempt to fix the test flakyness. I tried in #159, but apparently it didn't work. 

The problem is we are receiving "Network errors" while running e2e tests. I suspect that it is something related to the machine running these tests because in my local machine it always works. I'm trying to add some reasonable wait times to make sure it works.