### PR TITLE
Add ballot styles to the voter client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Added
+
+- The bulletin board client now accepts the `ballot_styles` param when creating an election.
+
 ## [0.16.1] - 2021-04-12
 
 ## [0.16.0] - 2021-04-06

--- a/Makefile
+++ b/Makefile
@@ -65,14 +65,16 @@ install: install_bulletin_board_server_js_dependencies \
 	install_voting_scheme_electionguard_js_dependencies \
 	install_voting_scheme_electionguard_ruby_dependencies
 
-clean:
-	rm -f ${BULLETIN_BOARD_CLIENT_JS_LIBRARY_OUTPUT}
-	rm -f ${VOTING_SCHEME_DUMMY_JS_LIBRARY_OUTPUT}
-	rm -f ${VOTING_SCHEME_ELECTIONGUARD_JS_LIBRARY_OUTPUT}
+clean: clean_javascript_artifacts
 	rm -rf ${VOTING_SCHEME_ELECTIONGUARD_RUBY_LIBRARY_PATH}/public
 	rm -rf ${ELECTIONGUARD_PYTHON_WRAPPER_PATH}/dist
 	rm -rf ${ELECTIONGUARD_PYTHON_TO_JS_PATH}/packages/bulletin_board-electionguard/dist/
 	rm -rf ${ELECTIONGUARD_PYTHON_TO_JS_PATH}/packages/electionguard/dist/
+
+clean_javascript_artifacts:
+	rm -f ${BULLETIN_BOARD_CLIENT_JS_LIBRARY_OUTPUT}
+	rm -f ${VOTING_SCHEME_DUMMY_JS_LIBRARY_OUTPUT}
+	rm -f ${VOTING_SCHEME_ELECTIONGUARD_JS_LIBRARY_OUTPUT}
 
 build: ${BULLETIN_BOARD_CLIENT_JS_LIBRARY_OUTPUT} \
 	${VOTING_SCHEME_DUMMY_JS_LIBRARY_OUTPUT} \

--- a/bulletin_board/js-client/src/vote/vote.component.js
+++ b/bulletin_board/js-client/src/vote/vote.component.js
@@ -77,8 +77,8 @@ export class VoteComponent {
       onStart();
       await onSetupDone;
       onVoteEncryption(
-        (plainVote) => {
-          this.voter.encrypt(plainVote).then((ballot) => {
+        (plainVote, ballotStyle) => {
+          this.voter.encrypt(plainVote, ballotStyle).then((ballot) => {
             castOrAuditBallot(ballot);
             onBindAuditBallotButton(() => {
               onAuditBallot(

--- a/bulletin_board/js-client/src/voter/voter-wrapper-adapter.js
+++ b/bulletin_board/js-client/src/voter/voter-wrapper-adapter.js
@@ -30,11 +30,12 @@ export class VoterWrapperAdapter {
    * encrypted data and the auditable data known as ballot.
    *
    * @param {Object} plainVote - An object with the choosen answers for each question.
+   * @param {String} ballotStyle - The ballot style identifier.
    *
    * @private
    * @returns {Promise<Object|undefined>}
    */
-  encrypt(_plainVote) {
+  encrypt(_plainVote, _ballotStyle) {
     throw new Error("Not implemented.");
   }
 }

--- a/bulletin_board/js-client/src/voter/voter.js
+++ b/bulletin_board/js-client/src/voter/voter.js
@@ -63,12 +63,14 @@ export class Voter {
    * Encrypts the data using the wrapper.
    *
    * @param {Object} plainVote - An object with the choosen answers for each question.
+   * @param {String} ballotStyle - The ballot style identifier.
    *
    * @returns {Promise<Object>} - The ballot.
    */
-  async encrypt(plainVote) {
+  async encrypt(plainVote, ballotStyle) {
     const { encryptedData, auditableData } = await this.wrapperAdapter.encrypt(
-      plainVote
+      plainVote,
+      ballotStyle
     );
     const encryptedDataHash = await this.hash(encryptedData);
 

--- a/bulletin_board/js-client/src/voter/voter.test.js
+++ b/bulletin_board/js-client/src/voter/voter.test.js
@@ -31,14 +31,20 @@ describe("Voter", () => {
         .mockImplementation(() =>
           Promise.resolve({ auditableBallot: {}, encryptedBallot: {} })
         );
-      await voter.encrypt({
-        question1: ["answer-1-option-a"],
-        question2: ["answer-2-option-a", "answer-2-option-b"],
-      });
-      expect(voter.wrapperAdapter.encrypt).toHaveBeenCalledWith({
-        question1: ["answer-1-option-a"],
-        question2: ["answer-2-option-a", "answer-2-option-b"],
-      });
+      await voter.encrypt(
+        {
+          question1: ["answer-1-option-a"],
+          question2: ["answer-2-option-a", "answer-2-option-b"],
+        },
+        null
+      );
+      expect(voter.wrapperAdapter.encrypt).toHaveBeenCalledWith(
+        {
+          question1: ["answer-1-option-a"],
+          question2: ["answer-2-option-a", "answer-2-option-b"],
+        },
+        null
+      );
     });
   });
 });

--- a/bulletin_board/ruby-client/lib/decidim/bulletin_board/authority/create_election.rb
+++ b/bulletin_board/ruby-client/lib/decidim/bulletin_board/authority/create_election.rb
@@ -55,7 +55,8 @@ module Decidim
               start_date: election_data[:start_date].strftime("%FT%T%:z"),
               end_date: election_data[:end_date].strftime("%FT%T%:z"),
               candidates: candidates,
-              contests: contests
+              contests: contests,
+              ballot_styles: ballot_styles
             }
           }
         end
@@ -124,6 +125,15 @@ module Decidim
             {
               object_id: answer[:slug],
               ballot_name: text(answer[:title])
+            }
+          end
+        end
+
+        def ballot_styles
+          election_data[:ballot_styles].map do |ballot_style_id, question_ids|
+            {
+              object_id: ballot_style_id,
+              contests: question_ids
             }
           end
         end

--- a/bulletin_board/ruby-client/lib/decidim/bulletin_board/authority/create_election.rb
+++ b/bulletin_board/ruby-client/lib/decidim/bulletin_board/authority/create_election.rb
@@ -132,7 +132,7 @@ module Decidim
         def ballot_styles
           election_data[:ballot_styles].map do |ballot_style_id, question_ids|
             {
-              object_id: ballot_style_id,
+              object_id: ballot_style_id.to_s,
               contests: question_ids
             }
           end

--- a/bulletin_board/ruby-client/spec/decidim/bulletin_board/authority/create_election_spec.rb
+++ b/bulletin_board/ruby-client/spec/decidim/bulletin_board/authority/create_election_spec.rb
@@ -103,7 +103,12 @@ module Decidim
                   "es": "Otra respuesta para otra pregunta"
                 }
               }
-            ]
+            ],
+            ballot_styles: {
+              "ballot_style_1": ["question-1"],
+              "ballot_style_2": ["question-2"],
+              "ballot_style_3": ["question-1", "question-2"]
+            }
           }
         end
 
@@ -181,7 +186,12 @@ module Decidim
                                                                 candidate_id: "answer-3" },
                                                               { object_id: "question-2_answer-4",
                                                                 sequence_order: 1,
-                                                                candidate_id: "answer-4" }] }] } }
+                                                                candidate_id: "answer-4" }] }],
+                             ballot_styles: [
+                               { object_id: "ballot_style_1", contests: ["question-1"] },
+                               { object_id: "ballot_style_2", contests: ["question-2"] },
+                               { object_id: "ballot_style_3", contests: ["question-1", "question-2"] }
+                             ] } }
           end
 
           it "broadcasts ok with the result of the graphql mutation" do

--- a/bulletin_board/server/app/assets/config/manifest.js
+++ b/bulletin_board/server/app/assets/config/manifest.js
@@ -18,3 +18,6 @@
 
 //= link sandbox/tally.js
 //= link sandbox/tally.css
+
+//= link sandbox/elections/new.css
+//= link sandbox/elections/new.js

--- a/bulletin_board/server/app/assets/javascripts/sandbox/elections/new.js
+++ b/bulletin_board/server/app/assets/javascripts/sandbox/elections/new.js
@@ -1,0 +1,103 @@
+//= require jquery
+
+$(() => {
+  const $addQuestionButton = $(".new_election__add-question-button");
+  const $questionTemplate = $(".question-template");
+  const $questionsPlaceholder = $(".new_election__form-questions-placeholder");
+  let questionIndex = 0;
+
+  const addQuestion = () => {
+    const currentQuestionIndex = questionIndex;
+    const newQuestionElement = $questionTemplate[0].cloneNode(true);
+    newQuestionElement.innerHTML = newQuestionElement.innerHTML.replace(
+      /{{questionIndex}}/g,
+      currentQuestionIndex
+    );
+    newQuestionElement.innerHTML = newQuestionElement.innerHTML.replace(
+      /{{questionIndexPlusOne}}/g,
+      currentQuestionIndex + 1
+    );
+    $questionsPlaceholder.append(
+      document.importNode(newQuestionElement.content, true)
+    );
+    questionIndex += 1;
+    return currentQuestionIndex;
+  };
+
+  $addQuestionButton.on("click", (event) => {
+    const lastIndexAdded = addQuestion();
+    $(".new_election__form-ballot-style-questions-placeholder").each(
+      (_, $ballotStyleQuestionPlaceholder) => {
+        addQuestionToExistingBallotStyle(
+          lastIndexAdded,
+          $ballotStyleQuestionPlaceholder
+        );
+      }
+    );
+    event.preventDefault();
+  });
+
+  const $addBallotStyleButton = $(".new_election__add-ballot-style-button");
+  const $ballotStyleTemplate = $(".ballot-style-template");
+  const $ballotStylesPlaceholder = $(
+    ".new_election__form-ballot-styles-placeholder"
+  );
+  const $ballotStyleQuestionTemplate = $(".ballot-style-question-template");
+  let ballotStyleIndex = 0;
+
+  const addBallotStyle = () => {
+    const newBallotStyleElement = $ballotStyleTemplate[0].cloneNode(true);
+    newBallotStyleElement.innerHTML = newBallotStyleElement.innerHTML.replace(
+      /{{ballotStyleIndexPlusOne}}/g,
+      ballotStyleIndex + 1
+    );
+
+    const ballotStyleNode = document.importNode(
+      newBallotStyleElement.content,
+      true
+    );
+
+    $(".election-question").each((questionIndex) => {
+      const $ballotStyleQuestionPlaceholder = $(ballotStyleNode).find(
+        ".new_election__form-ballot-style-questions-placeholder"
+      );
+      addQuestionToExistingBallotStyle(
+        questionIndex,
+        $ballotStyleQuestionPlaceholder
+      );
+    });
+
+    $ballotStylesPlaceholder.append(ballotStyleNode);
+    ballotStyleIndex += 1;
+  };
+
+  const addQuestionToExistingBallotStyle = (
+    questionIndex,
+    $ballotStyleQuestionPlaceholder
+  ) => {
+    const newBallotStyleQuestionElement = $ballotStyleQuestionTemplate[0].cloneNode(
+      true
+    );
+
+    newBallotStyleQuestionElement.innerHTML = newBallotStyleQuestionElement.innerHTML.replace(
+      /{{ballotStyleIndexPlusOne}}/g,
+      ballotStyleIndex + 1
+    );
+    newBallotStyleQuestionElement.innerHTML = newBallotStyleQuestionElement.innerHTML.replace(
+      /{{questionIndexPlusOne}}/g,
+      questionIndex + 1
+    );
+
+    $ballotStyleQuestionPlaceholder.append(
+      document.importNode(newBallotStyleQuestionElement.content, true)
+    );
+  };
+
+  $addBallotStyleButton.on("click", (event) => {
+    addBallotStyle();
+    event.preventDefault();
+  });
+
+  addQuestion();
+  addQuestion();
+});

--- a/bulletin_board/server/app/assets/stylesheets/sandbox/elections/new.scss
+++ b/bulletin_board/server/app/assets/stylesheets/sandbox/elections/new.scss
@@ -1,17 +1,9 @@
-.vote {
+.new_election {
   max-width: 900px;
   margin: 0 auto;
   font-size: 14px;
   &__intro {
     margin-bottom: 2rem;
-  }
-  &__form {
-    .done-message,
-    .audit-done-message,
-    .audit-vote,
-    .cast-vote {
-      display: none;
-    }
   }
   &__form-row {
     display: flex;
@@ -37,11 +29,9 @@
     input {
       padding: 0.2rem;
       margin-bottom: 0.2rem;
-      width: 20rem;
     }
     select {
       display: block;
-      width: 20rem;
     }
   }
   &__form-actions {

--- a/bulletin_board/server/app/controllers/sandbox/elections_controller.rb
+++ b/bulletin_board/server/app/controllers/sandbox/elections_controller.rb
@@ -6,7 +6,7 @@ module Sandbox
   class ElectionsController < ApplicationController
     helper_method :elections, :election
     helper_method :bulletin_board_server, :authority_slug, :authority_public_key
-    helper_method :base_vote, :random_voter_id
+    helper_method :random_voter_id
     helper_method :election_results
     helper_method :default_bulk_votes_number, :bulk_votes_file_name, :bulk_votes_file_exists?, :generated_votes_number
 
@@ -97,7 +97,8 @@ module Sandbox
         start_date: start_date,
         end_date: end_date,
         questions: questions,
-        answers: answers
+        answers: answers,
+        ballot_styles: ballot_styles
       )
     end
 
@@ -141,6 +142,10 @@ module Sandbox
           }
         end
       end
+    end
+
+    def ballot_styles
+      @ballot_styles ||= params.require(:election).permit(ballot_styles: {})[:ballot_styles].to_h.transform_values(&:keys)
     end
 
     def go_back
@@ -190,16 +195,6 @@ module Sandbox
         quorum: 2,
         number_of_trustees: 3
       }
-    end
-
-    def base_vote
-      @base_vote ||= election.manifest[:description][:contests].map do |contest|
-        [
-          contest[:object_id],
-          contest[:ballot_selections].sample(Random.rand(contest[:number_elected] + 1))
-                                     .map { |ballot_selection| ballot_selection[:object_id] }
-        ]
-      end.to_h.to_json
     end
 
     def random_voter_id

--- a/bulletin_board/server/app/helpers/sandbox/elections_helper.rb
+++ b/bulletin_board/server/app/helpers/sandbox/elections_helper.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Sandbox
+  module ElectionsHelper
+    def options_for_ballot_style_select(election)
+      options_for_select(election.manifest[:description][:ballot_styles].map { |ballot_style| ballot_style["object_id"] })
+    end
+
+    def election_questions_with_answers(election)
+      election.manifest[:description][:contests].inject({}) do |acc, contest|
+        acc[contest[:object_id]] = contest[:ballot_selections].map { |ballot_selection| ballot_selection[:object_id] }
+        acc
+      end
+    end
+
+    def ballot_style_classes(question_id)
+      election.manifest[:description][:ballot_styles].map do |ballot_style|
+        if ballot_style["contests"].include?(question_id)
+          ballot_style["object_id"]
+        else
+          ""
+        end
+      end.join(" ")
+    end
+
+    def has_ballot_styles?(election)
+      election.manifest[:description][:ballot_styles].length > 0
+    end
+  end
+end

--- a/bulletin_board/server/app/helpers/sandbox/elections_helper.rb
+++ b/bulletin_board/server/app/helpers/sandbox/elections_helper.rb
@@ -7,9 +7,8 @@ module Sandbox
     end
 
     def election_questions_with_answers(election)
-      election.manifest[:description][:contests].inject({}) do |acc, contest|
+      election.manifest[:description][:contests].each_with_object({}) do |contest, acc|
         acc[contest[:object_id]] = contest[:ballot_selections].map { |ballot_selection| ballot_selection[:object_id] }
-        acc
       end
     end
 
@@ -24,7 +23,7 @@ module Sandbox
     end
 
     def has_ballot_styles?(election)
-      election.manifest[:description][:ballot_styles].length > 0
+      election.manifest[:description][:ballot_styles].length.positive?
     end
   end
 end

--- a/bulletin_board/server/app/views/sandbox/elections/new.html.erb
+++ b/bulletin_board/server/app/views/sandbox/elections/new.html.erb
@@ -1,82 +1,139 @@
-<div class="intro">
-  <div class="version">Bulletin Board Version <%= Decidim::BulletinBoard::VERSION %></div>
+<%= stylesheet_link_tag "sandbox/elections/new" %>
 
-  <h1>Create election</h1>
-</div>
+<section class="new_election">
+  <div class="new_election__intro">
+    <div class="version">Bulletin Board Version <%= Decidim::BulletinBoard::VERSION %></div>
 
-<div class="info">
-  <%= link_to "Back", sandbox_elections_path %>
+    <h1>Create election</h1>
+    <%= link_to "Back", sandbox_elections_path %>
+  </div>
 
-  <form method="post" action="<%= sandbox_elections_path %>">
+  <form class="new_election__form" method="post" action="<%= sandbox_elections_path %>">
     <%= hidden_field_tag :authenticity_token, form_authenticity_token -%>
-    <ul>
-      <li>
-        <label>
-          Voting scheme name:
+    <div class="new_election__form-row">
+      <div class="new_election__form-column">
+        <div class="new_election__form-field">
+          <label>Voting scheme name</label>
           <select name="election[voting_scheme_name]">
             <option value="dummy">dummy</option>
             <option value="electionguard">electionguard</option>
           </select>
-        </label>
-      </li>
-      <li><label>Election ID: <input name="election[id]" type="text" value="<%= SecureRandom.base58 %>"></label></li>
-      <li><label>Default locale: <select name="election[default_locale]"><option>ca</option><option selected>en</option><option>es</option></select></label></li>
-      <li>
-        <label>Election title:
+        </div>
+        <div class="new_election__form-field">
+          <label>Election ID</label>
+          <input name="election[id]" type="text" value="<%= SecureRandom.base58 %>">
+        </div>
+        <div class="new_election__form-field">
+          <label>Default locale</label>
+          <select name="election[default_locale]">
+            <option>ca</option>
+            <option selected>en</option>
+            <option>es</option>
+          </select>
+        </div>
+        <div class="new_election__form-field">
+          <label>Election title</label>
           <input name="election[title][ca]" type="text" value="Votació de prova" placeholder="ca">
           <input name="election[title][en]" type="text" value="Test election" placeholder="en">
           <input name="election[title][es]" type="text" value="Votación de prueba" placeholder="es">
-        </label>
-      </li>
-      <li><label>Start date: <input name="election[start_date]" type="number" value="1"> days from now</label></li>
-      <li><label>End date: <input name="election[end_date]" type="number" value="1"> after the start</label></li>
-      <li>
-        <h2>Questions</h2>
-        <ul>
-        <% 2.times.each_with_index do |question_index| %>
-          <li><h3>Question #<%= question_index + 1 %></h3></li>
-          <li>
-              <label>Title:
-                <input name="election[questions][<%= question_index %>][title][ca]" type="text" value="Pregunta #<%= question_index + 1 %>" placeholder="ca">
-                <input name="election[questions][<%= question_index %>][title][en]" type="text" value="Question #<%= question_index + 1 %>" placeholder="en">
-                <input name="election[questions][<%= question_index %>][title][es]" type="text" value="Pregunta #<%= question_index + 1 %>" placeholder="es">
-              </label>
-          </li>
-          <li>
-              <label>Description:
-                <input name="election[questions][<%= question_index %>][description][ca]" type="text" value="Descripció #<%= question_index + 1 %>" placeholder="ca">
-                <input name="election[questions][<%= question_index %>][description][en]" type="text" value="Description #<%= question_index + 1 %>" placeholder="en">
-                <input name="election[questions][<%= question_index %>][description][es]" type="text" value="Descripción #<%= question_index + 1 %>" placeholder="es">
-              </label>
-          </li>
-          <li>
-              <label>Slug: <input name="election[questions][<%= question_index %>][slug]" type="text" value="question-<%= question_index + 1 %>"></label>
-          </li>
-          <li>
-              <label>Maximum selections: <input name="election[questions][<%= question_index %>][max_selections]" type="number" value="1" min="1" max="4"></label>
-          </li>
-          <li>
-              <h4>Answers: </h4>
-              <ul>
-                <% 2.times.each_with_index do |answer_index| %>
-                <li><h5>Answer #<%= question_index + 1 %>.<%= answer_index + 1 %></h5></li>
-                <li>
-                    <label>Title:
-                      <input name="election[questions][<%= question_index %>][answers][<%= answer_index %>][title][ca]" type="text" value="Resposta #<%= question_index + 1 %>.<%= answer_index + 1 %>" placeholder="ca">
-                      <input name="election[questions][<%= question_index %>][answers][<%= answer_index %>][title][en]" type="text" value="Answer #<%= question_index + 1 %>.<%= answer_index + 1 %>" placeholder="en">
-                      <input name="election[questions][<%= question_index %>][answers][<%= answer_index %>][title][es]" type="text" value="Respuesta #<%= question_index + 1 %>.<%= answer_index + 1 %>" placeholder="es">
-                    </label>
-                </li>
-                <li>
-                    <label>Slug: <input name="election[questions][<%= question_index %>][answers][<%= answer_index %>][slug]" type="text" value="answer-<%= question_index + 1 %>-<%= answer_index + 1 %>"></label>
-                </li>
-                <% end %>
-              </ul>
-          </li>
-        <% end %>
-        </ul>
-      </li>
-      <li><input type="submit" value="Create"></li>
-    </ul>
+        </div>
+      </div>
+      <div class="new_election__form-column">
+        <div class="new_election__form-field">
+          <label>Start date</label>
+          <input name="election[start_date]" type="number" value="1"> days from now
+        </div>
+        <div class="new_election__form-field">
+          <label>End date</label>
+          <input name="election[end_date]" type="number" value="1"> after the start
+        </div>
+      </div>
+    </div>
+    <h2>Questions</h2>
+    <div class="new_election__form-questions-placeholder"></div>
+    <button class="new_election__add-question-button">Add question</button>
+    <h2>Ballot styles</h2>
+    <div class="new_election__form-ballot-styles-placeholder"></div>
+    <button class="new_election__add-ballot-style-button">Add ballot style</button>
+    <div class="new_election__form-actions">
+      <input type="submit" value="Create">
+    </div>
   </form>
-</div>
+</section>
+
+<template class="question-template">
+  <h3>Question {{questionIndexPlusOne}}</h3>
+  <div class="new_election__form-row election-question">
+    <div class="new_election__form-column">
+      <div class="new_election__form-field">
+        <label>Title</label>
+        <input name="election[questions][{{questionIndex}}][title][ca]" type="text" value="Pregunta {{questionIndexPlusOne}}" placeholder="ca">
+        <input name="election[questions][{{questionIndex}}][title][en]" type="text" value="Question {{questionIndexPlusOne}}" placeholder="en">
+        <input name="election[questions][{{questionIndex}}][title][es]" type="text" value="Pregunta {{questionIndexPlusOne}}" placeholder="es">
+      </div>
+      <div class="new_election__form-field">
+        <label>Description</label>
+        <input name="election[questions][{{questionIndex}}][description][ca]" type="text" value="Descripció {{questionIndexPlusOne}}" placeholder="ca">
+        <input name="election[questions][{{questionIndex}}][description][en]" type="text" value="Description {{questionIndexPlusOne}}" placeholder="en">
+        <input name="election[questions][{{questionIndex}}][description][es]" type="text" value="Descripción {{questionIndexPlusOne}}" placeholder="es">
+      </div>
+    </div>
+    <div class="new_election__form-column">
+      <div class="new_election__form-field">
+        <label>Slug</label>
+        <input name="election[questions][{{questionIndex}}][slug]" type="text" value="question-{{questionIndexPlusOne}}">
+      </div>
+      <div class="new_election__form-field">
+        <label>Maximum selections</label>
+        <input name="election[questions][{{questionIndex}}][max_selections]" type="number" value="1" min="1" max="4" readonly>
+      </div>
+    </div>
+  </div>
+  <h4>Answers</h4>
+  <div class="new_election__form-row">
+    <div class="new_election__form-column">
+      <div class="new_election__form-field">
+        <label>Title</label>
+        <input name="election[questions][{{questionIndex}}][answers][0][title][ca]" type="text" value="Resposta {{questionIndexPlusOne}}" placeholder="ca">
+        <input name="election[questions][{{questionIndex}}][answers][0][title][en]" type="text" value="Answer {{questionIndexPlusOne}}" placeholder="en">
+        <input name="election[questions][{{questionIndex}}][answers][0][title][es]" type="text" value="Respuesta {{questionIndexPlusOne}}" placeholder="es">
+      </div>
+    </div>
+    <div class="new_election__form-column">
+      <div class="new_election__form-field">
+        <label>Slug</label>
+        <input name="election[questions][{{questionIndex}}][answers][0][slug]" type="text" value="question-{{questionIndexPlusOne}}-1">
+      </div>
+    </div>
+  </div>
+  <div class="new_election__form-row">
+    <div class="new_election__form-column">
+      <div class="new_election__form-field">
+        <label>Title</label>
+        <input name="election[questions][{{questionIndex}}][answers][1][title][ca]" type="text" value="Resposta {{questionIndexPlusOne}}" placeholder="ca">
+        <input name="election[questions][{{questionIndex}}][answers][1][title][en]" type="text" value="Answer {{questionIndexPlusOne}}" placeholder="en">
+        <input name="election[questions][{{questionIndex}}][answers][1][title][es]" type="text" value="Respuesta {{questionIndexPlusOne}}" placeholder="es">
+      </div>
+    </div>
+    <div class="new_election__form-column">
+      <div class="new_election__form-field">
+        <label>Slug</label>
+        <input name="election[questions][{{questionIndex}}][answers][1][slug]" type="text" value="question-{{questionIndexPlusOne}}-2">
+      </div>
+    </div>
+  </div>
+</template>
+
+<template class="ballot-style-template">
+  <h3>Ballot Style {{ballotStyleIndexPlusOne}}</h3>
+  <div class="new_election__form-row ballot-style new_election__form-ballot-style-questions-placeholder"></div>
+</template>
+
+<template class="ballot-style-question-template">
+  <div class="new_election__form-column">
+    <label>question-{{questionIndexPlusOne}}</label>
+    <input type="checkbox" name="election[ballot_styles][ballot-style-{{ballotStyleIndexPlusOne}}][question-{{questionIndexPlusOne}}]" checked>
+  </div>
+</template>
+
+<%= javascript_include_tag "sandbox/elections/new" %>

--- a/bulletin_board/server/app/views/sandbox/elections/new.html.erb
+++ b/bulletin_board/server/app/views/sandbox/elections/new.html.erb
@@ -13,15 +13,15 @@
     <div class="new_election__form-row">
       <div class="new_election__form-column">
         <div class="new_election__form-field">
-          <label>Voting scheme name</label>
-          <select name="election[voting_scheme_name]">
+          <label for="election_voting_scheme_name">Voting scheme name</label>
+          <select id="election_voting_scheme_name" name="election[voting_scheme_name]">
             <option value="dummy">dummy</option>
             <option value="electionguard">electionguard</option>
           </select>
         </div>
         <div class="new_election__form-field">
-          <label>Election ID</label>
-          <input name="election[id]" type="text" value="<%= SecureRandom.base58 %>">
+          <label for="election_id">Election ID</label>
+          <input id="election_id" name="election[id]" type="text" value="<%= SecureRandom.base58 %>">
         </div>
         <div class="new_election__form-field">
           <label>Default locale</label>
@@ -32,8 +32,8 @@
           </select>
         </div>
         <div class="new_election__form-field">
-          <label>Election title</label>
-          <input name="election[title][ca]" type="text" value="Votació de prova" placeholder="ca">
+          <label for="election_title">Election title</label>
+          <input id="election_title" name="election[title][ca]" type="text" value="Votació de prova" placeholder="ca">
           <input name="election[title][en]" type="text" value="Test election" placeholder="en">
           <input name="election[title][es]" type="text" value="Votación de prueba" placeholder="es">
         </div>

--- a/bulletin_board/server/app/views/sandbox/elections/vote.html.erb
+++ b/bulletin_board/server/app/views/sandbox/elections/vote.html.erb
@@ -1,34 +1,52 @@
 <%= stylesheet_link_tag "sandbox/vote" %>
 
-<div class="intro">
-  <div class="version">Bulletin Board Version <%= Decidim::BulletinBoard::VERSION %></div>
+<section class="vote">
+  <div class="vote__intro">
+    <div class="version">Bulletin Board Version <%= Decidim::BulletinBoard::VERSION %></div>
 
-  <h1>Vote for <%= election.title.values.first %></h1>
-</div>
+    <h1>Vote for <%= election.title.values.first %></h1>
+    <%= link_to "Back", sandbox_elections_path %>
+  </div>
 
-<div class="info">
-  <%= link_to "Back", sandbox_elections_path %>
-
-  <div class="voter"
-       data-election-unique-id="<%= election.unique_id %>"
-       data-api-endpoint-url="<%= bulletin_board_server %>"
-       data-authority-public-key="<%= authority_public_key %>"
-       data-voting-scheme-name="<%= election.voting_scheme_name %>">
-    <p>Voter Id: <input name="voter_id" value="<%= random_voter_id %>" style="width:20rem"></p>
-
-    <label>Vote content:
-      <textarea cols="100" rows="5"><%= base_vote %></textarea>
-    </label>
-
-    <p>
-      <button class="encrypt-vote">Encrypt vote</button>
-    </p>
+  <form
+    target="!#"
+    class="vote__form voter"
+    data-election-unique-id="<%= election.unique_id %>"
+    data-api-endpoint-url="<%= bulletin_board_server %>"
+    data-authority-public-key="<%= authority_public_key %>"
+    data-voting-scheme-name="<%= election.voting_scheme_name %>">
+    <div class="vote__form-row">
+      <div class="vote__form-column">
+        <div class="vote__form-field">
+          <label>Voter ID</label>
+          <input name="voter_id" value="<%= random_voter_id %>">
+        </div>
+      </div>
+      <% if has_ballot_styles?(election) %>
+        <div class="vote__form-column">
+          <div class="vote__form-field">
+            <label>Ballot Style</label>
+            <select name="ballot_style">
+              <%= options_for_ballot_style_select(election) %>
+            </select>
+          </div>
+        </div>
+      <% end %>
+    </div>
+    <div class="vote__form-row">
+      <% election_questions_with_answers(election).each do |question_id, answer_ids| %>
+        <div class="vote__form-column question <%= ballot_style_classes(question_id) %>">
+          <p><%= question_id %></p>
+          <% answer_ids.each do |answer_id| %>
+            <label><%= answer_id %></label>
+            <input name="<%= question_id %>" value="<%= answer_id %>" type="radio" <%= Random.rand > 0.5 ? 'checked' : '' %>>
+          <% end %>
+          <input name="<%= question_id %>" type="hidden">
+        </div>
+      <% end %>
+    </div>
     <p class="benchmark"></p>
     <p class="ballot-hash"></p>
-    <p>
-      <button class="audit-vote">Audit vote</button>
-      <button class="cast-vote">Cast vote</button>
-    </p>
     <p>
       <span class="done-message">Your vote has been casted successfully</span>
       <span class="audit-done-message">Your vote has been audited successfully</span>
@@ -36,7 +54,12 @@
     <p>
       <a href="">Refresh</a>
     </p>
-  </div>
-</div>
+    <div class="vote__form-actions">
+      <button class="encrypt-vote">Encrypt vote</button>
+      <button class="audit-vote">Audit vote</button>
+      <button class="cast-vote">Cast vote</button>
+    </div>
+  </form>
+</section>
 
 <%= javascript_include_tag "sandbox/vote" %>

--- a/bulletin_board/server/cypress/integration/sandbox/election.page.js
+++ b/bulletin_board/server/cypress/integration/sandbox/election.page.js
@@ -218,11 +218,13 @@ export class ElectionPage {
    */
   castVote() {
     cy.findByText("Vote").click();
-    cy.findByLabelText(/Vote content/)
-      .invoke("text")
-      .then((vote) => {
-        this.castedVotes.push(Object.values(JSON.parse(vote)).flat());
-      });
+
+    // Extract the votes answers from the form
+    cy.get("input[type=radio]").then(($radio) => {
+      if ($radio.is("checked")) {
+        $radio.invoke("val").then((vote) => this.castedVotes.push(vote));
+      }
+    });
 
     if (this.votingSchemeName === "electionguard") {
       // Wait a decent amount of time to make sure electionguard is loaded.

--- a/voting_schemes/dummy/js-adapter/src/voter_wrapper.js
+++ b/voting_schemes/dummy/js-adapter/src/voter_wrapper.js
@@ -42,12 +42,13 @@ export class VoterWrapper {
    * Converts the given vote into an auditable ballot and an encrypted Ballot. As the process is very fast,
    * it simulates the delay of the encryption process.
    *
-   * @param {Object} vote - An object with the choosen answers for each question.
+   * @param {Object} plainVote - An object with the choosen answers for each question.
+   * @param {String} ballotStyle - The ballot style identifier.
    *
    * @private
    * @returns {Promise<Object|undefined>}
    */
-  async encrypt(vote) {
+  async encrypt(plainVote, _ballotStyle) {
     return new Promise((resolve) => setTimeout(resolve, WAIT_TIME_MS)).then(
       () => {
         if (!this.jointElectionKey) {
@@ -55,7 +56,7 @@ export class VoterWrapper {
           return;
         }
 
-        const auditableData = this.createAuditableBallot(vote);
+        const auditableData = this.createAuditableBallot(plainVote);
         const encryptedData = JSON.stringify(
           this.createEncryptedData(JSON.parse(JSON.stringify(auditableData)))
         );

--- a/voting_schemes/dummy/js-adapter/src/voter_wrapper_adapter.js
+++ b/voting_schemes/dummy/js-adapter/src/voter_wrapper_adapter.js
@@ -43,11 +43,12 @@ export class VoterWrapperAdapter {
    * encrypted data and the auditable data known as ballot.
    *
    * @param {Object} plainVote - An object with the choosen answers for each question.
+   * @param {String} ballotStyle - The ballot style identifier.
    *
    * @private
    * @returns {Promise<Object|undefined>}
    */
-  encrypt(plainVote) {
-    return this.wrapper.encrypt(plainVote);
+  encrypt(plainVote, ballotStyle) {
+    return this.wrapper.encrypt(plainVote, ballotStyle);
   }
 }

--- a/voting_schemes/electionguard/js-adapter/src/voter_wrapper_adapter.js
+++ b/voting_schemes/electionguard/js-adapter/src/voter_wrapper_adapter.js
@@ -74,18 +74,20 @@ export class VoterWrapperAdapter extends WrapperAdapter {
    * encrypted data and the auditable data known as ballot.
    *
    * @param {Object} plainVote - An object with the choosen answers for each question.
+   * @param {String} ballotStyle - The ballot style identifier.
    *
    * @private
    * @returns {Promise<Object|undefined>}
    */
-  async encrypt(plainVote) {
+  async encrypt(plainVote, ballotStyle) {
     const [auditableData, encryptedData] = await this.processPythonCodeOnWorker(
       `
-      from js import plain_vote
-      voter.encrypt(plain_vote)
+      from js import plain_vote, ballot_style
+      voter.encrypt(plain_vote, ballot_style)
     `,
       {
         plain_vote: plainVote,
+        ballot_style: ballotStyle,
       }
     );
 

--- a/voting_schemes/electionguard/python-wrapper/src/bulletin_board/electionguard/election.py
+++ b/voting_schemes/electionguard/python-wrapper/src/bulletin_board/electionguard/election.py
@@ -49,7 +49,7 @@ def _translate_ballot_styles(
         elif (
             "contests" in ballot_style
         ):  # flag that indicates we need to fake some geopolitical units
-            contest_ids = {id for id in ballot_style["contests"]}
+            contest_ids = [id for id in ballot_style["contests"]]
             for id in contest_ids:
                 unique_contest_ids.add(id)
             ballot_styles.append(
@@ -70,7 +70,7 @@ def _translate_ballot_styles(
             name=f"{contest_id} Geopolitical Unit",
             type=ReportingUnitType.county,
         )
-        for contest_id in unique_contest_ids
+        for contest_id in sorted(unique_contest_ids)
     ]
 
 


### PR DESCRIPTION
In this pull request I am using #164 in the frontend part. When voting you can select the ballot style you want to use if any.

I needed to change the sandbox a bit so I added some improvements:
- When creating an election you can add multiple questions.
- When creating an election you can add multiple ballot styles. If you add a question afterwards all ballot styles are updated accordingly.
- When voting you can select the ballot style you want to use.
- When voting you can answer questions using a simple form.

https://user-images.githubusercontent.com/106021/114390619-c9ebb700-9b96-11eb-9b77-1ea05ee3974a.mov

https://user-images.githubusercontent.com/106021/114390999-3c5c9700-9b97-11eb-90c8-fd96232d0d25.mov



