### PR TITLE
Use the correct main file in the bulletin board js client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Fixed
+
+- Use the correct main file in the bulletin board javascript client.
+
 ## [0.17.0] - 2021-04-12
 
 ## Added

--- a/bulletin_board/js-client/package.json
+++ b/bulletin_board/js-client/package.json
@@ -2,7 +2,7 @@
   "name": "@codegram/decidim-bulletin_board",
   "version": "0.17.0",
   "description": "",
-  "main": "index.js",
+  "main": "src/index.js",
   "scripts": {
     "build": "webpack -c webpack.config.js --progress",
     "build:watch": "webpack -c webpack.config.js --progress --watch",


### PR DESCRIPTION
This fixes the bulletin board javascript client so it can be used in `decidim` with `Webpacker`.