### PR TITLE
Expose verifiable results in get results GraphQL query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Changed
+
+- The bulletin board client also gets the election's verifiable data along with its results
+
 ## [0.20.0] - 2021-04-22
 
 ## Changed

--- a/bulletin_board/ruby-client/lib/decidim/bulletin_board/authority/get_election_results.rb
+++ b/bulletin_board/ruby-client/lib/decidim/bulletin_board/authority/get_election_results.rb
@@ -44,7 +44,7 @@ module Decidim
           @election = response.data.election
           @signed_data = election.log_entries.first.signed_data
 
-          broadcast(:ok, { election_results: decoded_data["results"], verifiable_results: verifiable_results } )
+          broadcast(:ok, { election_results: decoded_data["results"], verifiable_results: verifiable_results })
         rescue Graphlient::Errors::ServerError
           broadcast(:error, "Sorry, something went wrong")
         end

--- a/bulletin_board/ruby-client/lib/decidim/bulletin_board/authority/get_election_results.rb
+++ b/bulletin_board/ruby-client/lib/decidim/bulletin_board/authority/get_election_results.rb
@@ -33,22 +33,25 @@ module Decidim
                 logEntries(types: args[:types]) do
                   signedData
                 end
+                verifiableResultsUrl
+                verifiableResultsHash
               end
             end
           end
 
           return broadcast(:error, "There aren't any log entries with type: 'end_tally' for this election.") if response.data.election.log_entries.empty?
 
-          @signed_data = response.data.election.log_entries.first.signed_data
+          @election = response.data.election
+          @signed_data = election.log_entries.first.signed_data
 
-          broadcast(:ok, decoded_data["results"])
+          broadcast(:ok, { election_results: decoded_data["results"], verifiable_results: verifiable_results } )
         rescue Graphlient::Errors::ServerError
           broadcast(:error, "Sorry, something went wrong")
         end
 
         private
 
-        attr_reader :election_id, :types, :signed_data
+        attr_reader :election_id, :types, :signed_data, :election
 
         def decoded_data
           @decoded_data ||= begin
@@ -56,6 +59,13 @@ module Decidim
           rescue JWT::VerificationError, JWT::DecodeError, JWT::InvalidIatError, JWT::InvalidPayload => e
             { error: e.message }
           end
+        end
+
+        def verifiable_results
+          {
+            url: election.verifiable_results_url,
+            hash: election.verifiable_results_hash
+          }
         end
       end
     end

--- a/bulletin_board/ruby-client/spec/decidim/bulletin_board/authority/get_election_results_spec.rb
+++ b/bulletin_board/ruby-client/spec/decidim/bulletin_board/authority/get_election_results_spec.rb
@@ -32,7 +32,7 @@ module Decidim
 
           it "uses the graphql client to perform an election query, decodes the the response and returns the encoded data" do
             subject.on(:ok) do |result|
-              expect(result).to eq( { election_results: { "23" => { "66" => 0, "67" => 0, "68" => 0, "69" => 4 }, "24" => { "70" => 0, "71" => 1, "72" => 1 } }, verifiable_results: { url: verifiable_results_url, hash: verifiable_results_hash } } )
+              expect(result).to eq({ election_results: { "23" => { "66" => 0, "67" => 0, "68" => 0, "69" => 4 }, "24" => { "70" => 0, "71" => 1, "72" => 1 } }, verifiable_results: { url: verifiable_results_url, hash: verifiable_results_hash } })
             end
             subject.call
           end

--- a/bulletin_board/ruby-client/spec/decidim/bulletin_board/authority/get_election_results_spec.rb
+++ b/bulletin_board/ruby-client/spec/decidim/bulletin_board/authority/get_election_results_spec.rb
@@ -16,10 +16,14 @@ module Decidim
             election: {
               logEntries: [{
                 signedData: "eyJhbGciOiJSUzI1NiJ9.eyJtZXNzYWdlX2lkIjoiZGVjaWRpbS10ZXN0LWF1dGhvcml0eS45LmVuZF90YWxseStiLmJ1bGxldGluLWJvYXJkIiwiaWF0IjoxNjEyMjgyMTIxLCJyZXN1bHRzIjp7IjIzIjp7IjY3IjowLCI2NiI6MCwiNjkiOjQsIjY4IjowfSwiMjQiOnsiNzAiOjAsIjcxIjoxLCI3MiI6MX19fQ.eRMuWoCZ0l7YiSc5o2odiQZI1cxO0pRli_IjjtB1n9FNgEYpZyMfKADD8q7x4Y5ANv-fen-kLbi9r0Zzvx_uKIS0S8zizjKPJY5Npxz2DnBxUxULHFfsUO7q1cnDwDqkp6KTfTUlsDh7DmjLgxoSyyGA9euMpwvli6wgVEFlecIZWGxuP_dgxULyEvSPwlhg3PalZMuVKiASDvJmCFSQpBBgqNbMWidSVXtt6Msoob5SyIjLes5B8JSOsN_vCr6gI6rtK7h0rIyNcVhB9vQcLVsgfO8vTP4bcWciiVD_wnQvf5_JLbrHywudQooLBRnL8HLO7iHm4MkdpBzYcfG-5rvdq7RX50ISY3m9qfxdWRr3QbhkBAct4iPB3voy2ewvMLBPehRlZ_Pzl-ZVkmuk8Sb-AaGpm9DhE0gnx-ZBZ3bkVVz50Rq5nk5m7dlTvDFKCW85TGpWmZJIFA72H6k969BDloQXUGhtlV_wgE7bZP6BWiABzTf7euwnrQ4YWLbhGYaxlEKo5s9d_LQmPObfRvVVcyx6sd1ba4HmwuDIaXTSHAmTyLYvgeuWPHkf7q1Vg9KWO5Zst1EwW-K80ikBbIVU7fzkdfO8MYwRA22MxW-bg7jI8RT5_wlApF3IKMMxG0rz5gh3Zgsie8vCCXOy3s0LNW_Ymlc2d8n8gyPATv4"
-              }]
+              }],
+              verifiableResultsUrl: verifiable_results_url,
+              verifiableResultsHash: verifiable_results_hash
             }
           }
         end
+        let(:verifiable_results_url) { "some-url" }
+        let(:verifiable_results_hash) { "some-hash" }
 
         context "when everything is ok" do
           it "broadcasts ok with the result of the graphql query" do
@@ -27,8 +31,8 @@ module Decidim
           end
 
           it "uses the graphql client to perform an election query, decodes the the response and returns the encoded data" do
-            subject.on(:ok) do |decoded_data|
-              expect(decoded_data).to eq({ "23" => { "66" => 0, "67" => 0, "68" => 0, "69" => 4 }, "24" => { "70" => 0, "71" => 1, "72" => 1 } })
+            subject.on(:ok) do |result|
+              expect(result).to eq( { election_results: { "23" => { "66" => 0, "67" => 0, "68" => 0, "69" => 4 }, "24" => { "70" => 0, "71" => 1, "72" => 1 } }, verifiable_results: { url: verifiable_results_url, hash: verifiable_results_hash } } )
             end
             subject.call
           end

--- a/bulletin_board/server/app/controllers/sandbox/elections_controller.rb
+++ b/bulletin_board/server/app/controllers/sandbox/elections_controller.rb
@@ -7,7 +7,7 @@ module Sandbox
     helper_method :elections, :election,
                   :bulletin_board_server, :authority_slug, :authority_public_key,
                   :random_voter_id,
-                  :election_results,
+                  :election_results, :verifiable_results,
                   :default_bulk_votes_number, :bulk_votes_file_name, :bulk_votes_file_exists?, :generated_votes_number,
                   :pending_message
 
@@ -88,7 +88,9 @@ module Sandbox
     end
 
     def results
-      @election_results = bulletin_board_client.get_election_results(election_id)
+      results = bulletin_board_client.get_election_results(election_id)
+      @election_results = results[:election_results]
+      @verifiable_results = results[:verifiable_results]
     end
 
     private
@@ -96,7 +98,7 @@ module Sandbox
     delegate :authority, to: :election
     delegate :bulletin_board_server, :authority_slug, to: :bulletin_board_client
 
-    attr_reader :election_results, :pending_message
+    attr_reader :election_results, :verifiable_results, :pending_message
 
     def election_data
       @election_data ||= params.require(:election).permit(:default_locale, title: {}).to_h.merge(

--- a/bulletin_board/server/app/views/sandbox/elections/results.html.erb
+++ b/bulletin_board/server/app/views/sandbox/elections/results.html.erb
@@ -19,4 +19,12 @@
       </ul>
     <% end %>
   </div>
+
+  <div class="results__content">
+    <h2>Verifiable Results</h2>
+      <ul>
+        <li><strong>Hash</strong>: <%= verifiable_results[:hash] %></li>
+        <li><strong>File</strong>: <%= link_to "download here", verifiable_results[:url] %></li>
+      </ul>
+  </div>
 </section>


### PR DESCRIPTION
The ruby client now also asks for the election's verifiable data (the hash and the file's path) with the `get_election_results` query.
This changes slightly the structure of the response, that will need to be adapted in Decidim.

The sandbox has been updated to show the new data retrieved.

![image](https://user-images.githubusercontent.com/5033945/115702799-a4fefd00-a369-11eb-8e2b-b28788ab2b24.png)
