### PR TITLE
Return data for election log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Changed
+
+- `GetElectionLogEntries` now returns `chainedHash`
+- The `MessageParser` gets exported individually
+
 ## [0.21.0] - 2021-04-22
 
 ## Changed

--- a/bulletin_board/js-client/src/client/__mocks__/graphql-client.js
+++ b/bulletin_board/js-client/src/client/__mocks__/graphql-client.js
@@ -8,10 +8,12 @@ const logEntriesByElection = {
           {
             signedData: "1234",
             contentHash: "h1234",
+            chainedHash: "c1234",
           },
           {
             signedData: "5678",
             contentHash: "h5678",
+            chainedHash: "c5678",
           },
         ],
       },
@@ -24,6 +26,7 @@ const logEntriesByElection = {
           {
             signedData: "9012",
             contentHash: "h9012",
+            chainedHash: "c9012",
           },
         ],
       },

--- a/bulletin_board/js-client/src/client/client.test.js
+++ b/bulletin_board/js-client/src/client/client.test.js
@@ -33,6 +33,7 @@ describe("Client", () => {
       expect(entry).toEqual({
         signedData: "1234",
         contentHash: "h1234",
+        chainedHash: "c1234",
       });
     });
   });

--- a/bulletin_board/js-client/src/client/graphql-client.test.js
+++ b/bulletin_board/js-client/src/client/graphql-client.test.js
@@ -48,8 +48,8 @@ describe("GraphQLClient", () => {
   describe("getElectionLogEntries", () => {
     it("returns all the log entries given a election id", async () => {
       const logEntriesResult = [
-        { messageId: "dummy.1", signedData: "1234" },
-        { messageId: "dummy.2", signedData: "5678" },
+        { messageId: "dummy.1", signedData: "1234", chainedHash: "c1234" },
+        { messageId: "dummy.2", signedData: "5678", chainedHash: "c5678" },
       ];
 
       fetch.mockResponseOnce(

--- a/bulletin_board/js-client/src/client/operations/get_election_log_entries.gql
+++ b/bulletin_board/js-client/src/client/operations/get_election_log_entries.gql
@@ -8,6 +8,7 @@ query GetElectionLogEntries(
       id
       messageId
       signedData
+      chainedHash
     }
   }
 }

--- a/bulletin_board/js-client/src/index.js
+++ b/bulletin_board/js-client/src/index.js
@@ -1,7 +1,8 @@
 import { Client } from "./client/client";
-import { Election } from ".//election/election";
+import { Election } from "./election/election";
 import { Trustee } from "./trustee/trustee";
 import { Voter } from "./voter/voter";
+import { MessageParser } from "./client/message-parser";
 import { MessageIdentifier } from "./client/message-identifier";
 import { MESSAGE_RECEIVED, MESSAGE_PROCESSED } from "./trustee/event_manager";
 import { IdentificationKeys } from "./trustee/identification_keys";
@@ -14,6 +15,7 @@ export {
   Election,
   Trustee,
   Voter,
+  MessageParser,
   MessageIdentifier,
   MESSAGE_PROCESSED,
   MESSAGE_RECEIVED,


### PR DESCRIPTION
Now, when querying for `GetElectionLogEntries`, you get the `chainedHash` as well. Also, the `MessageParser` is exported. With that, you can now access the `iat` from Decidim without exposing the whole `decodedData`.

The `chainedHash` will be part of the `Election Log` on Decidim.