### PR TITLE
Use the correct docker image as base image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM codegram/ruby-node-python-electionguard:355b587ea9c4e80c9228183e5c2da68bc40f2afa
+FROM codegram/ruby-node-python-electionguard:ruby-2.6.6-node-15-python-3.8.8-electionguard-355b587ea9c4e80c9228183e5c2da68bc40f2afa
 LABEL author="david@codegram.com"
 
 # [Option] Install zsh

--- a/.dockerignore
+++ b/.dockerignore
@@ -48,3 +48,6 @@
 
 /voting_schemes/electionguard/python-to-js/packages/bulletin_board-electionguard/dist
 /voting_schemes/electionguard/python-to-js/packages/electionguard/dist
+
+# Ignore python-wrapper environment files
+/voting_schemes/electionguard/python-wrapper/.venv

--- a/.github/workflows/server-workflow.yml
+++ b/.github/workflows/server-workflow.yml
@@ -19,7 +19,7 @@ jobs:
     name: Build electionguard
     runs-on: ubuntu-latest
     container:
-      image: codegram/ruby-node-python-electionguard:355b587ea9c4e80c9228183e5c2da68bc40f2afa
+      image: codegram/ruby-node-python-electionguard:ruby-2.6.6-node-15-python-3.8.8-electionguard-355b587ea9c4e80c9228183e5c2da68bc40f2afa
     steps:
       - uses: actions/checkout@v2.0.0
         with:
@@ -121,7 +121,7 @@ jobs:
     needs: build_python_to_js
     runs-on: ubuntu-latest
     container:
-      image: codegram/ruby-node-python-electionguard:355b587ea9c4e80c9228183e5c2da68bc40f2afa
+      image: codegram/ruby-node-python-electionguard:ruby-2.6.6-node-15-python-3.8.8-electionguard-355b587ea9c4e80c9228183e5c2da68bc40f2afa
     services:
       postgres:
         image: postgres:11
@@ -234,7 +234,7 @@ jobs:
     needs: [check_python_to_js_cache, build_python_to_js]
     runs-on: ubuntu-latest
     container:
-      image: codegram/ruby-node-python-electionguard:355b587ea9c4e80c9228183e5c2da68bc40f2afa
+      image: codegram/ruby-node-python-electionguard:ruby-2.6.6-node-15-python-3.8.8-electionguard-355b587ea9c4e80c9228183e5c2da68bc40f2afa
     services:
       postgres:
         image: postgres:11

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,5 +1,5 @@
 # This stage builds the python-wrapper package
-FROM codegram/ruby-node-python-electionguard:355b587ea9c4e80c9228183e5c2da68bc40f2afa as python-wrapper-builder
+FROM codegram/ruby-node-python-electionguard:ruby-2.6.6-node-15-python-3.8.8-electionguard-355b587ea9c4e80c9228183e5c2da68bc40f2afa as python-wrapper-builder
 LABEL author="david@codegram.com"
 
 # Add Makefile
@@ -38,7 +38,7 @@ RUN make
 RUN cp -rf /code/voting_schemes/electionguard/python-to-js/override/* /src/pyodide/build/
 
 # This stage builds the bulletin-board application
-FROM codegram/ruby-node-python-electionguard:355b587ea9c4e80c9228183e5c2da68bc40f2afa
+FROM codegram/ruby-node-python-electionguard:ruby-2.6.6-node-15-python-3.8.8-electionguard-355b587ea9c4e80c9228183e5c2da68bc40f2afa
 LABEL author="david@codegram.com"
 
 # Environment variables

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,5 +1,5 @@
 # This stage builds the python-wrapper package
-FROM codegram/ruby-node-python-electionguard:355b587ea9c4e80c9228183e5c2da68bc40f2afa as python-wrapper-builder
+FROM codegram/ruby-node-python-electionguard:ruby-2.6.6-node-15-python-3.8.8-electionguard-355b587ea9c4e80c9228183e5c2da68bc40f2afa as python-wrapper-builder
 LABEL author="david@codegram.com"
 
 # Add Makefile
@@ -38,7 +38,7 @@ RUN make
 RUN cp -rf /code/voting_schemes/electionguard/python-to-js/override/* /src/pyodide/build/
 
 # This stage builds the bulletin-board application
-FROM codegram/ruby-node-python-electionguard:355b587ea9c4e80c9228183e5c2da68bc40f2afa
+FROM codegram/ruby-node-python-electionguard:ruby-2.6.6-node-15-python-3.8.8-electionguard-355b587ea9c4e80c9228183e5c2da68bc40f2afa
 LABEL author="david@codegram.com"
 
 # Environment variables


### PR DESCRIPTION
While I was deploying this to `staging` I detected some problems related to the docker base image that includes everything (ruby, node, python and electionguard).

I decided to change its name schema (it's horrible, I know 😅 ) to include all the versions to avoid problems in the future. Previously it was just using the SHA of electionguard commit but if we changed something like the python version the name didn't reflect the change.

Also, I realized that we were including some config data like `.venv` in the docker image mistakenly. This caused some problems while building the docker image in my machine.