### PR TITLE
Only load assets if defined Sprockets

### DIFF
--- a/bulletin_board/ruby-client/lib/decidim/bulletin_board/engine.rb
+++ b/bulletin_board/ruby-client/lib/decidim/bulletin_board/engine.rb
@@ -7,8 +7,10 @@ module Decidim
     class Engine < ::Rails::Engine
       isolate_namespace Decidim::BulletinBoard
 
-      initializer "decidim_bulletin_board.assets" do |app|
-        app.config.assets.precompile += %w(decidim_bulletin_board_manifest.js)
+      if defined?(Sprockets) && Sprockets::VERSION.chr.to_i >= 4
+        initializer "decidim_bulletin_board.assets" do |app|
+          app.config.assets.precompile += %w(decidim_bulletin_board_manifest.js)
+        end
       end
     end
   end


### PR DESCRIPTION
This PR allows BB to play nice with Decidim when we remove Sprockets dependency (as part of the Webpacker migration) by only loading assets if it's defined.


