### PR TITLE
Add alias for unique_id

### DIFF
--- a/.github/workflows/server-workflow.yml
+++ b/.github/workflows/server-workflow.yml
@@ -283,7 +283,7 @@ jobs:
           mkdir -p voting_schemes/electionguard/ruby-adapter/public/assets/electionguard
           cp -r /cache/python-to-js/electionguard-assets/* voting_schemes/electionguard/ruby-adapter/public/assets/electionguard
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libpq-dev libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+        run: sudo apt-get update --allow-releaseinfo-change && sudo apt-get install -y libpq-dev libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
       - name: Cache Ruby dependencies
         uses: actions/cache@v2
         env:

--- a/bulletin_board/server/app/models/bulletin_board.rb
+++ b/bulletin_board/server/app/models/bulletin_board.rb
@@ -72,6 +72,8 @@ class BulletinBoard
       name.parameterize
     end
 
+    alias unique_id slug
+
     def configured?
       private_key.present?
     end

--- a/bulletin_board/server/spec/models/bulletin_board_spec.rb
+++ b/bulletin_board/server/spec/models/bulletin_board_spec.rb
@@ -3,8 +3,9 @@
 require "rails_helper"
 
 RSpec.describe "BulletinBoard" do
-  let!(:private_key) { Decidim::BulletinBoard::JwkUtils.import_private_key(Rails.application.secrets.bulletin_board_private_key) }
   subject { BulletinBoard }
+
+  let!(:private_key) { Decidim::BulletinBoard::JwkUtils.import_private_key(Rails.application.secrets.bulletin_board_private_key) }
 
   before do
     subject
@@ -31,11 +32,11 @@ RSpec.describe "BulletinBoard" do
   end
 
   it "is not destroyed by default" do
-    expect(subject).to_not be_destroyed
+    expect(subject).not_to be_destroyed
   end
 
   it "is not a new record by default" do
-    expect(subject).to_not be_new_record
+    expect(subject).not_to be_new_record
   end
 
   it "has a type of BulletinBoard" do

--- a/bulletin_board/server/spec/models/bulletin_board_spec.rb
+++ b/bulletin_board/server/spec/models/bulletin_board_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "BulletinBoard" do
+  let!(:private_key) { Decidim::BulletinBoard::JwkUtils.import_private_key(Rails.application.secrets.bulletin_board_private_key) }
+  subject { BulletinBoard }
+
+  before do
+    subject
+  end
+
+  it "sets id as primary key" do
+    expect(subject.primary_key).to eq(:id)
+  end
+
+  it "sets 0 as id default" do
+    expect(subject.id).to eq(0)
+  end
+
+  it "is readonly by default" do
+    expect(subject).to be_readonly
+  end
+
+  it "is persisted by default" do
+    expect(subject).to be_persisted
+  end
+
+  it "sets polymorphic_name to Bulletin Board" do
+    expect(subject.polymorphic_name).to eq("Bulletin Board")
+  end
+
+  it "is not destroyed by default" do
+    expect(subject).to_not be_destroyed
+  end
+
+  it "is not a new record by default" do
+    expect(subject).to_not be_new_record
+  end
+
+  it "has a type of BulletinBoard" do
+    expect(subject.type).to eq("BulletinBoard")
+  end
+
+  it "has a public key" do
+    expect(subject.public_key).to eq(private_key&.export)
+  end
+
+  it "has a name of Bulletin Board" do
+    expect(subject.name).to eq("Bulletin Board")
+  end
+
+  it "is a bulletin_board" do
+    expect(subject).to be_bulletin_board
+  end
+
+  it "'s slug is the name parameterized" do
+    expect(subject.slug).to eq("bulletin-board")
+  end
+
+  it "has an alias for slug called unique_id" do
+    expect(subject.unique_id).to eq(subject.slug)
+  end
+
+  it "is configered when private key is present" do
+    expect(subject.configured?).to eq(true)
+  end
+end


### PR DESCRIPTION
We renamed the `unique_id` method to `slug`. Therefore, we got an error when trying to retrieve the `id` of the `client`. This PR adds an `alias` for the `slug` method.

<img width="1493" alt="query with alias method" src="https://user-images.githubusercontent.com/19774772/129700558-a4fe20e4-520f-4f6f-abbb-87ffdb11f0c3.png">
