### PR TITLE
Improve dummy compensation procedure

### DIFF
--- a/bulletin_board/server/spec/factories/models.rb
+++ b/bulletin_board/server/spec/factories/models.rb
@@ -39,7 +39,7 @@ FactoryBot.define do
     authority { Authority.first }
     status { :created }
     unique_id { [authority.unique_id, election_id].join(".") }
-    voting_scheme_state { nil }
+    voting_scheme_state { Marshal.dump(quorum: 2) }
 
     after(:build) do |election, evaluator|
       election.trustees << evaluator.trustees_plus_keys.map(&:first)
@@ -57,12 +57,13 @@ FactoryBot.define do
       end
 
       status { :key_ceremony }
-      voting_scheme_state { Marshal.dump(joint_election_key: 1, trustees: trustees_done.map(&:slug)) }
+      voting_scheme_state { Marshal.dump(quorum: 2, joint_election_key: 1, trustees: trustees_done.map(&:slug)) }
     end
 
     trait :key_ceremony_ended do
       status { :key_ceremony_ended }
-      voting_scheme_state { Marshal.dump(joint_election_key: 1, trustees: trustees_plus_keys.map(&:first).map(&:slug)) }
+      voting_scheme_state { Marshal.dump(quorum: 2, joint_election_key: Test::Elections.joint_election_key,
+                                         trustees: trustees_plus_keys.map(&:first).map(&:slug)) }
     end
 
     trait :vote do
@@ -85,14 +86,15 @@ FactoryBot.define do
 
       after(:build) do |election, evaluator|
         joint_shares = Test::Elections.build_cast(election) { 1 }
-        election.voting_scheme_state = Marshal.dump(joint_election_key: Test::Elections.joint_election_key,
+        election.voting_scheme_state = Marshal.dump(quorum: 2,
+                                                    joint_election_key: Test::Elections.joint_election_key,
                                                     trustees: evaluator.trustees_plus_keys.map(&:first).map(&:slug),
                                                     joint_shares: joint_shares,
                                                     shares: evaluator.trustees_done.map(&:slug),
-                                                    compensations: {}, joint_compensations: {},
-                                                    compensated: 0)
+                                                    compensations: [], joint_compensations: {}, missing: [])
       end
     end
+
 
     trait :tally_ended do
       status { :tally_ended }
@@ -103,8 +105,7 @@ FactoryBot.define do
                                                     trustees: evaluator.trustees_plus_keys.map(&:first).map(&:slug),
                                                     joint_shares: joint_shares,
                                                     shares: evaluator.trustees_plus_keys.map(&:first).map(&:slug),
-                                                    compensations: {}, joint_compensations: {},
-                                                    compensated: 0)
+                                                    compensations: [], joint_compensations: {}, missing: [])
       end
     end
 

--- a/bulletin_board/server/spec/factories/models.rb
+++ b/bulletin_board/server/spec/factories/models.rb
@@ -62,8 +62,10 @@ FactoryBot.define do
 
     trait :key_ceremony_ended do
       status { :key_ceremony_ended }
-      voting_scheme_state { Marshal.dump(quorum: 2, joint_election_key: Test::Elections.joint_election_key,
-                                         trustees: trustees_plus_keys.map(&:first).map(&:slug)) }
+      voting_scheme_state do
+        Marshal.dump(quorum: 2, joint_election_key: Test::Elections.joint_election_key,
+                     trustees: trustees_plus_keys.map(&:first).map(&:slug))
+      end
     end
 
     trait :vote do
@@ -94,7 +96,6 @@ FactoryBot.define do
                                                     compensations: [], joint_compensations: {}, missing: [])
       end
     end
-
 
     trait :tally_ended do
       status { :tally_ended }

--- a/voting_schemes/dummy/js-adapter/src/trustee_wrapper.js
+++ b/voting_schemes/dummy/js-adapter/src/trustee_wrapper.js
@@ -54,6 +54,7 @@ export class TrusteeWrapper {
           this.quorum = decodedData.scheme.quorum;
           this.status = CREATED;
         }
+        break;
       }
       case CREATED: {
         if (messageType === START_KEY_CEREMONY) {


### PR DESCRIPTION
This PR fixes some problems with the compensation in the dummy voting scheme:
- It was starting to do things before reaching the quorum.
- It didn't work for all the combinations of number of trustees, quorum and missing trustees.

The new system works like this:
- For each trustee `t`, it calculates it's share: S<sub>`t`</sub> = result * key<sub>`t`</sub>
- When there is at least one missing trustee, the trustees wait until all the active trustees send their shares.
- We will use indexes starting with `m` for missing trustees, and starting with `a` for active trustees.
- Then, the trustees calculate their compensations: C<sub>`at`</sub> = (result<sup>`M`</sup>) / (key<sub>`at`</sub>)<sup>`A`</sup>, where `M` is the number of missing trustees and `A` is number of active trustees.

When the BB receives all the compensations, it uses them to calculate the multiplication of all the missing shares, that will be used to complete the decryption:

(C<sub>`a1`</sub> * ... * C<sub>`aA`</sub>)<sup>`1/A`</sup> * joint_key = 

((result<sup>`M`</sup>) / (key<sub>`a1`</sub>)<sup>`A`</sup> * ... * (result<sup>`M`</sup>) / (key<sub>`aA`</sub>)<sup>`A`</sup>)<sup>`1/A`</sup> * joint_key =

(result<sup>`M/A`</sup>) / key<sub>`a1`</sub> * ... * (result<sup>`M/A`</sup>) / key<sub>`aA`</sub> * (key<sub>`1`</sub> * ... * key<sub>`N`</sub>) =

(result<sup>`M/A`</sup>)<sup>`A`</sup> * (key<sub>`1`</sub> * ... * key<sub>`N`</sub>) / (key<sub>`a1`</sub> * ... * key<sub>`aA`</sub>) = 

result<sup>`M`</sup> * key<sub>`m1`</sub> * ... * key<sub>`mM`</sub> =

result * key<sub>`m1`</sub> * ... * result * key<sub>`mM`</sub> = 

S<sub>`m1`</sub> * ... * S<sub>`mM`</sub>
