### PR TITLE
Fix broken check of results during e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ update_changelog:
 	sed -i.bak -E "s/## Unreleased/## Unreleased\n\n## [${VERSION}] - `date +'%Y-%m-%d'`/g" CHANGELOG.md
 
 commit_and_push:
-	git commit -am "chore: bump to version ${VERSION}"
+	git commit -am "Bump to version ${VERSION}"
 	git push
 	git tag v${VERSION}
 	git push --tags

--- a/bulletin_board/server/app/services/voting_scheme/dummy/bulletin_board.rb
+++ b/bulletin_board/server/app/services/voting_scheme/dummy/bulletin_board.rb
@@ -164,6 +164,8 @@ module VotingScheme
             results[question][answer] = ((joint_share / state[:joint_election_key])**(1.0 / state[:trustees].count)).round
           end
         end
+
+        results
       end
 
       def build_questions_struct(initial_value)

--- a/bulletin_board/server/cypress/integration/sandbox/election.page.js
+++ b/bulletin_board/server/cypress/integration/sandbox/election.page.js
@@ -218,12 +218,14 @@ export class ElectionPage {
    *
    * @returns {undefined}
    */
-  castVote(voterId = null) {
+  castVote(voterId = null, countAsCast = true) {
     cy.findByText("Vote").click();
 
     // Extract the votes answers from the form
     cy.get("input[type=checkbox]").then(($checkbox) => {
-      this.castedVotes.push($checkbox.serializeArray());
+      if (countAsCast) {
+        this.castedVotes.push($checkbox.serializeArray());
+      }
     });
 
     if (voterId) {

--- a/bulletin_board/server/cypress/integration/sandbox/election.page.js
+++ b/bulletin_board/server/cypress/integration/sandbox/election.page.js
@@ -223,9 +223,7 @@ export class ElectionPage {
 
     // Extract the votes answers from the form
     cy.get("input[type=checkbox]").then(($checkbox) => {
-      if ($checkbox.is("checked")) {
-        $checkbox.invoke("val").then((vote) => this.castedVotes.push(vote));
-      }
+      this.castedVotes.push($checkbox.serializeArray());
     });
 
     if (voterId) {
@@ -483,15 +481,19 @@ export class ElectionPage {
    * @returns {undefined}
    */
   assertCorrectResults() {
-    const flatVotes = this.castedVotes.flat();
-    const totals = {};
+    cy.get(".results__content").then(() => {
+      const flatVotes = this.castedVotes.flat();
+      expect(flatVotes).not.to.be.empty;
+      cy.log(JSON.stringify(flatVotes));
 
-    for (const i in flatVotes) {
-      totals[flatVotes[i]] = (totals[flatVotes[i]] || 0) + 1; // increments count if element already exists
-    }
+      const totals = {};
+      flatVotes.forEach((vote) => {
+        totals[vote.value] = (totals[vote.value] || 0) + 1; // increments count if element already exists
+      });
 
-    for (const answer in Object.keys(totals)) {
-      cy.findByText(`${answer}: ${totals[answer]}`).should("be.visible");
-    }
+      Object.entries(totals).forEach((total) => {
+        cy.findByText(`${total[0]}: ${total[1]}`).should("be.visible");
+      });
+    });
   }
 }

--- a/bulletin_board/server/cypress/integration/sandbox/election.spec.js
+++ b/bulletin_board/server/cypress/integration/sandbox/election.spec.js
@@ -90,18 +90,14 @@ describe("Election", () => {
       electionVotingSchemeName: "dummy",
       doTheVoting: () => {
         const voterId = "e98a86b62b97c18129a6be1f890578f069eff369";
-        page.castVote(voterId);
+        page.castVote(voterId, false);
         page.assertVoteHasBeenAccepted();
         page.inPersonVote(voterId);
         page.assertInPersonVoteHasBeenAccepted();
-        page.castVote(voterId);
+        page.castVote(voterId, false);
         page.assertVoteHasBeenRejected();
         page.inPersonVote(voterId);
         page.assertInPersonVoteHasBeenRejected();
-
-        // No votes are going to be counted.
-        // (there was only one online vote, and it was overriden by the in person vote)
-        page.castedVotes = [];
 
         page.castVote(); // Add one vote to have a ballot to tally
         page.assertVoteHasBeenAccepted();

--- a/voting_schemes/dummy/js-adapter/src/trustee_wrapper.js
+++ b/voting_schemes/dummy/js-adapter/src/trustee_wrapper.js
@@ -112,8 +112,8 @@ export class TrusteeWrapper {
 
           return this._compensate();
         } else if (messageType === TALLY_MISSING_TRUSTEE) {
-          if (!(decodedData.truestee_id in this.trusteesShares)) {
-            this.trusteesShares[decodedData.truestee_id] = false;
+          if (!(decodedData.trustee_id in this.trusteesShares)) {
+            this.trusteesShares[decodedData.trustee_id] = false;
             return this._compensate();
           }
         } else if (messageType === END_TALLY) {

--- a/voting_schemes/dummy/js-adapter/src/trustee_wrapper.js
+++ b/voting_schemes/dummy/js-adapter/src/trustee_wrapper.js
@@ -200,6 +200,7 @@ export class TrusteeWrapper {
 
     if (
       missingTrustees > 0 &&
+      missingTrustees <= trusteesCount - this.quorum &&
       Object.keys(this.trusteesShares).length === trusteesCount
     ) {
       const contests = JSON.parse(this.tallyCastMessage);

--- a/voting_schemes/dummy/js-adapter/src/voter_wrapper.js
+++ b/voting_schemes/dummy/js-adapter/src/voter_wrapper.js
@@ -94,7 +94,8 @@ export class VoterWrapper {
             return {
               object_id: ballotSelection.object_id,
               ciphertext:
-                plaintext + Math.floor(random * 500) * this.jointElectionKey,
+                plaintext +
+                Math.floor(random * 500 + 1) * this.jointElectionKey,
               random,
               plaintext,
             };

--- a/voting_schemes/dummy/js-adapter/src/voter_wrapper.test.js
+++ b/voting_schemes/dummy/js-adapter/src/voter_wrapper.test.js
@@ -93,13 +93,13 @@ describe("VoterWrapper", () => {
 
         expect(response.encryptedData).toEqual(
           `{"ballot_style":"ballot-style","contests":[{"object_id":"question-1","ballot_selections":[{"object_id":"question-1-answer-1","ciphertext":${
-            250 * 123456789 + 1
+            251 * 123456789 + 1
           }},{"object_id":"question-1-answer-2","ciphertext":${
-            250 * 123456789
+            251 * 123456789
           }}]},{"object_id":"question-2","ballot_selections":[{"object_id":"question-2-answer-1","ciphertext":${
-            250 * 123456789
+            251 * 123456789
           }},{"object_id":"question-2-answer-2","ciphertext":${
-            250 * 123456789 + 1
+            251 * 123456789 + 1
           }}]}]}`
         );
       });
@@ -116,13 +116,13 @@ describe("VoterWrapper", () => {
             {
               ballot_selections: [
                 {
-                  ciphertext: 30864197251,
+                  ciphertext: 30987654040,
                   object_id: "question-1-answer-1",
                   plaintext: 1,
                   random: 0.5,
                 },
                 {
-                  ciphertext: 30864197250,
+                  ciphertext: 30987654039,
                   object_id: "question-1-answer-2",
                   plaintext: 0,
                   random: 0.5,
@@ -133,13 +133,13 @@ describe("VoterWrapper", () => {
             {
               ballot_selections: [
                 {
-                  ciphertext: 30864197250,
+                  ciphertext: 30987654039,
                   object_id: "question-2-answer-1",
                   plaintext: 0,
                   random: 0.5,
                 },
                 {
-                  ciphertext: 30864197251,
+                  ciphertext: 30987654040,
                   object_id: "question-2-answer-2",
                   plaintext: 1,
                   random: 0.5,


### PR DESCRIPTION
This PR fixes a bug during E2E tests: the correctness of the results were not being checked. This prevented a bug on the results calculation on the dummy voting scheme to be catched. That bug is also fixed on this PR.
Other fixes on the dummy scheme are included in the PR:
* A small typo on the JS client.
* The trustee checks for the quorum before sending the compensation.
* The voters will not use 0 as a random value for "ciphering" the values. This fixes #199.

Finally, the release process was modified to use commit messages without prefixes.