### PR TITLE
Remove production database ENV VARs

### DIFF
--- a/bulletin_board/server/config/database.yml
+++ b/bulletin_board/server/config/database.yml
@@ -85,5 +85,4 @@ test:
 production:
   <<: *default
   database: decidim_bulletin_board_production
-  username: decidim_bulletin_board
-  password: <%= ENV['DECIDIM_BULLETIN_BOARD_DATABASE_PASSWORD'] %>
+


### PR DESCRIPTION
While setting up a local instance of the bulletin board server app, I've seen a couple of settings in config/database.yml that didn't make much sense for me, as this already can be implemented through the default ENV VARS (DATABASE_USERNAME and DATABASE_PASSWORD).

As they'd be difficult to explain in the documentation I think it'd be better to just drop them.

I've made a little archeology and it comes from the [initial commit](https://github.com/decidim/decidim-bulletin-board/blob/ca026e78fdc2dfa0e145c20da94a06e10a7b2300/config/database.yml#L84). 