### PR TITLE
Fix CI workflow system dependencies installation

### DIFF
--- a/.github/workflows/server-workflow.yml
+++ b/.github/workflows/server-workflow.yml
@@ -170,7 +170,7 @@ jobs:
           mkdir -p voting_schemes/electionguard/ruby-adapter/public/assets/electionguard
           cp -r /cache/python-to-js/electionguard-assets/* voting_schemes/electionguard/ruby-adapter/public/assets/electionguard
       - name: Install system dependencies
-        run: sudo apt-get install -y libpq-dev
+        run: sudo apt-get update && sudo apt-get install -y libpq-dev
       - name: Cache Ruby dependencies
         uses: actions/cache@v2
         env:


### PR DESCRIPTION
While working in other PRs I found out that the [CI is broken in "[CI] Server (Unit tests)"](https://github.com/decidim/decidim-bulletin-board/runs/4936538768?check_suite_focus=true), because it's trying to install dependencies that don't exist anymore in the APT repositories. 

The error is:

```bash

## Install system dependencies 

Run sudo apt-get install -y libpq-dev
  sudo apt-get install -y libpq-dev
  shell: sh -e {0}
  env:
    CI: true
    SIMPLECOV: true
    ACTIONS_ALLOW_UNSECURE_COMMANDS: true
    DATABASE_USERNAME: postgres
    DATABASE_PASSWORD: postgres
    DATABASE_HOST: postgres
Reading package lists...
Building dependency tree...
Reading state information...
The following additional packages will be installed:
  libpq5
Suggested packages:
  postgresql-doc-11
The following packages will be upgraded:
  libpq-dev libpq5
2 upgraded, 0 newly installed, 0 to remove and 50 not upgraded.
Need to get 336 kB of archives.
After this operation, 0 B of additional disk space will be used.
Ign:1 http://deb.debian.org/debian buster/main amd64 libpq-dev amd64 11.12-0+deb10u1
Ign:2 http://deb.debian.org/debian buster/main amd64 libpq5 amd64 11.12-0+deb10u1
Err:1 http://deb.debian.org/debian buster/main amd64 libpq-dev amd64 11.12-0+deb10u1
  404  Not Found [IP: 151.101.210.132 80]
Err:2 http://deb.debian.org/debian buster/main amd64 libpq5 amd64 11.12-0+deb10u1
  404  Not Found [IP: 151.101.210.132 80]
E: Failed to fetch http://security.debian.org/debian-security/pool/updates/main/p/postgresql-11/libpq-dev_11.12-0+deb10u1_amd64.deb  404  Not Found [IP: 151.101.210.132 80]
E: Failed to fetch http://security.debian.org/debian-security/pool/updates/main/p/postgresql-11/libpq5_11.12-0+deb10u1_amd64.deb  404  Not Found [IP: 151.101.210.132 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Process completed with exit code 100.
```


This PR fixes that. 
