### PR TITLE
Clarify example groups description in JwkUtils spec

### DIFF
--- a/bulletin_board/ruby-client/spec/decidim/bulletin_board/jwk_utils_spec.rb
+++ b/bulletin_board/ruby-client/spec/decidim/bulletin_board/jwk_utils_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Decidim::BulletinBoard::JwkUtils do
 
   subject { described_class }
 
-  context "when working with a private key" do
+  context "when working with an invalid private key" do
     let(:json) { PUBLIC_KEY }
     let(:jwk) { JWT::JWK.import(json) }
 
@@ -41,7 +41,7 @@ RSpec.describe Decidim::BulletinBoard::JwkUtils do
     end
   end
 
-  context "when working with a private key" do
+  context "when working with a valid private key" do
     let(:json) { PRIVATE_KEY }
     let(:jwk) { Decidim::BulletinBoard::JwkUtils.import_private_key(json) }
 


### PR DESCRIPTION
We have a linter error regarding the RSpec/RepeatedExampleGroupDescription rubocop rule [in CI](https://github.com/decidim/decidim-bulletin-board/runs/5034143468?check_suite_focus=true). 

This PR fixes it. 

## Stacktrace 

```bash
Run bundle exec rubocop -P
Inspecting 48 files
.......................................C........

Offenses:

spec/decidim/bulletin_board/jwk_utils_spec.rb:29:3: C: RSpec/RepeatedExampleGroupDescription: Repeated context block description on line(s) [44]
  context "when working with a private key" do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/decidim/bulletin_board/jwk_utils_spec.rb:44:3: C: RSpec/RepeatedExampleGroupDescription: Repeated context block description on line(s) [29]
  context "when working with a private key" do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

48 files inspected, 2 offenses detected, 2 offenses auto-correctable
Error: Process completed with exit code 1.
```
