### PR TITLE
Fix broken links in documentation

### DIFF
--- a/docs/modules/admin/pages/validate-election-results.adoc
+++ b/docs/modules/admin/pages/validate-election-results.adoc
@@ -29,7 +29,7 @@ If their user also has other kinds of admin access, though, those will be preser
 
 Entering the Voting they want to validate, the Monitoring Committee Member can access the actions they want to perform from the left-hand menu.
 
-image::monitoring-commitee-admin-menu.png.png[Actions of the Monitoring Committee Member]
+image::monitoring-commitee-admin-menu.png[Actions of the Monitoring Committee Member]
 
 === Validate Certificates
 

--- a/docs/modules/develop/pages/index.adoc
+++ b/docs/modules/develop/pages/index.adoc
@@ -1,0 +1,4 @@
+= Develop
+
+* xref:develop:guide.adoc[Guide]
+* xref:develop:manual.adoc[Manual]


### PR DESCRIPTION
There are few things broken currently in the bulletin board documentation:
1. The `monitoring-commitee-admin-menu.png` image in the validate election results documentation
2. Missing index page for the "Develop" section

Because of these, the documentation site build is currently broken, so I want to get it fixed.

- Related to decidim/documentation#104