### PR TITLE
Run make install before python packaging at the python-wrapper

### DIFF
--- a/voting_schemes/electionguard/python-wrapper/Makefile
+++ b/voting_schemes/electionguard/python-wrapper/Makefile
@@ -25,7 +25,10 @@ test:
 	python3 -m pipenv run python setup.py install
 	python3 -m pipenv run pytest
 
-package:
+package: install \
+	package_python
+
+package_python:
 	python3 -m pipenv run python setup.py sdist bdist_wheel
 	python3 -m pipenv run python setup.py install
 	python3 setup.py install


### PR DESCRIPTION
I had the package task failing when building the Docker container, so `make install` should be run before packaging.

This is probably related to some latest changes since this did not happen during the previous releases (e.g. #286).