### PR TITLE
Fix issue with OpenSSL 3.0

### DIFF
--- a/.github/workflows/ruby-client-workflow.yml
+++ b/.github/workflows/ruby-client-workflow.yml
@@ -55,7 +55,7 @@ jobs:
   rspec-test:
     name: RSpec tests
     needs: lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: rokroskar/workflow-run-cleanup-action@v0.3.2
         if: "github.ref != 'refs/heads/develop'"

--- a/bulletin_board/ruby-client/lib/decidim/bulletin_board/jwk_utils.rb
+++ b/bulletin_board/ruby-client/lib/decidim/bulletin_board/jwk_utils.rb
@@ -13,13 +13,8 @@ module Decidim
         (json.keys & JWK_PRIVATE_FIELDS).any?
       end
 
-      # TODO: remove everything below here when https://github.com/jwt/ruby-jwt/pull/375 is released
       def self.import_private_key(json)
-        jwk = JWT::JWK.import(json)
-        jwk.keypair.set_key(decode_open_ssl_bn(json[:n]), decode_open_ssl_bn(json[:e]), decode_open_ssl_bn(json[:d]))
-        jwk.keypair.set_factors(decode_open_ssl_bn(json[:p]), decode_open_ssl_bn(json[:q]))
-        jwk.keypair.set_crt_params(decode_open_ssl_bn(json[:dp]), decode_open_ssl_bn(json[:dq]), decode_open_ssl_bn(json[:qi]))
-        jwk
+        JWT::JWK.import(json)
       end
 
       def self.private_export(jwk)


### PR DESCRIPTION
There is still a compatibility issue in the Bulletin Board with OpenSSL 3.0.

The comment is stating that after jwt/ruby-jwt#375 is merged and released, the extra stuff in the import code is no longer needed which seems to make sense looking at the changes in that PR. These changes became part of [jwt-2.2.3](https://github.com/jwt/ruby-jwt/releases/tag/v2.2.3) (2021-04-19), so these should no longer be needed.

When running the current code under OpenSSL 3.0, you will see the following exception:
```
     @bulletin_board ||= Decidim::BulletinBoard::Client.new
     
     OpenSSL::PKey::PKeyError:
       rsa#set_key= is incompatible with OpenSSL 3.0
     # /home/ahukkanen/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/decidim-bulletin_board-0.24.0/lib/decidim/bulletin_board/jwk_utils.rb:19:in `set_key'
     # /home/ahukkanen/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/decidim-bulletin_board-0.24.0/lib/decidim/bulletin_board/jwk_utils.rb:19:in `import_private_key'
     # /home/ahukkanen/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/decidim-bulletin_board-0.24.0/lib/decidim/bulletin_board/settings.rb:13:in `initialize'
     # /home/ahukkanen/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/decidim-bulletin_board-0.24.0/lib/decidim/bulletin_board/client.rb:26:in `new'
     # /home/ahukkanen/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/decidim-bulletin_board-0.24.0/lib/decidim/bulletin_board/client.rb:26:in `initialize'
```

Therefore, we should remove this code as stated in the comment and let `jwt` itself handle this part.