### PR TITLE
Change the Elections' setup minimum hours before start setting to 1 hour

### DIFF
--- a/bulletin_board/server/config/settings.yml
+++ b/bulletin_board/server/config/settings.yml
@@ -1,7 +1,7 @@
 default: &default
   iat_expiration_minutes: 60
   create_election:
-    hours_before: 2
+    hours_before: 1
 
 development:
   <<: *default


### PR DESCRIPTION
This is the other part of https://github.com/decidim/decidim/pull/10900. See that for more details and the explanation, but basically: working with Elections is painful because you need to wait a lot of time between tryouts. This PR fixes it by changing the default parameter to 1 hour. 