### PR TITLE
Fix the rubocop configuration URL

### DIFF
--- a/voting_schemes/dummy/ruby-adapter/.rubocop.yml
+++ b/voting_schemes/dummy/ruby-adapter/.rubocop.yml
@@ -1,4 +1,4 @@
-inherit_from: https://raw.githubusercontent.com/decidim/decidim/develop/.rubocop_ruby.yml
+inherit_from: https://raw.githubusercontent.com/decidim/decidim/develop/decidim-dev/config/rubocop/ruby.yml
 
 AllCops:
   Include:

--- a/voting_schemes/electionguard/ruby-adapter/.rubocop.yml
+++ b/voting_schemes/electionguard/ruby-adapter/.rubocop.yml
@@ -1,4 +1,4 @@
-inherit_from: https://raw.githubusercontent.com/decidim/decidim/develop/.rubocop_ruby.yml
+inherit_from: https://raw.githubusercontent.com/decidim/decidim/develop/decidim-dev/config/rubocop/ruby.yml
 
 AllCops:
   Include:


### PR DESCRIPTION
With https://github.com/decidim/decidim/pull/10578 we've changed where the rubocop configuration is on the main repository. 

Currently some linting workflows are broken in the `develop` branch: 

https://github.com/decidim/decidim-bulletin-board/actions/runs/5142715203/jobs/9256792760
https://github.com/decidim/decidim-bulletin-board/actions/runs/5142715210/jobs/9256792775

This PR fixes it on this repository. 
